### PR TITLE
Add hvac_action, state attributes, and fix BLE reconnect on restart

### DIFF
--- a/custom_components/velit/ac_client.py
+++ b/custom_components/velit/ac_client.py
@@ -178,12 +178,23 @@ class VelitACClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        self._client = BleakClient(
+        client = BleakClient(
             self._address,
             disconnected_callback=self._on_disconnect,
         )
-        await self._client.connect()
-        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._client = client
+        try:
+            await client.connect()
+            await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        except Exception:
+            # Disconnect before re-raising so BlueZ releases this connection and
+            # any stale notification subscription — prevents "Notify acquired" on
+            # the next attempt.
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+            raise
         self._connected = True
         self.unavailable = False
         self._consecutive_failures = 0
@@ -342,6 +353,11 @@ class VelitACClient:
 
     def _on_disconnect(self, _client: BleakClient) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
+        if not self._connected:
+            # The disconnect fired during a failed connect() attempt —
+            # _connected was never set True. connect() handles its own cleanup;
+            # do not start a reconnect loop here.
+            return
         self._connected = False
         _LOGGER.warning("Connection lost to %s", self._address)
         if self._pending and not self._pending.done():

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -82,9 +82,8 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     """Climate entity for a Velit heater (protocol V1.02).
 
     HVAC modes:
-      OFF       — heater is shut down
-      HEAT      — heater running (manual or thermostat preset)
-      FAN_ONLY  — ventilation only (func 0x03 / 0x04)
+      OFF   — heater is shut down
+      HEAT  — heater running (manual or thermostat preset)
 
     Presets (only meaningful in HEAT mode):
       manual      — fixed gear, no thermostat
@@ -93,7 +92,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     Fan modes: gear levels 1–5 (only meaningful in manual mode).
     """
 
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.FAN_ONLY]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
     _attr_preset_modes = ["manual", "thermostat"]
     _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -132,10 +131,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         state = self.coordinator.data["machine_state"]
         if state == 0:
             return HVACMode.OFF
-        work_mode = self.coordinator.data["work_mode"]
-        # Gear 0 with no work mode implies ventilation only.
-        if work_mode == 0:
-            return HVACMode.FAN_ONLY
         return HVACMode.HEAT
 
     @property
@@ -203,8 +198,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator._client.send_command(0x02, bytes([0x00]))
-        elif hvac_mode == HVACMode.FAN_ONLY:
-            await self.coordinator._client.send_command(0x03, bytes([0x00]))
         elif hvac_mode == HVACMode.HEAT:
             # Start in the currently selected preset mode.
             mode_byte = (

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -17,6 +17,7 @@ from typing import Any
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -163,6 +164,37 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         if self.coordinator.data is None:
             return None
         return str(self.coordinator.data["current_gear"])
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Current action shown on the climate card.
+
+        Maps machine state and fault code to an HVACAction so the climate card
+        reflects what the device is doing, not just what mode it is set to.
+        """
+        if self.coordinator.data is None:
+            return None
+        # Any active fault — device is not operational.
+        if self.coordinator.data["fault_code"] != 0:
+            return HVACAction.OFF
+        state = self.coordinator.data["machine_state"]
+        if state == 1:
+            return HVACAction.HEATING
+        if state == 2:
+            # Fan running to cool combustion chamber after shutdown.
+            return HVACAction.FAN
+        # Standby, overtemp standby, cleaning, clean complete — no active output.
+        return HVACAction.IDLE
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose machine state and fault as automation-accessible attributes."""
+        if self.coordinator.data is None:
+            return {}
+        return {
+            "machine_state": self.coordinator.data.get("machine_state_str"),
+            "fault": self.coordinator.data.get("fault_name"),
+        }
 
     # ------------------------------------------------------------------
     # Actions — send command then refresh to confirm state

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -182,12 +182,23 @@ class VelitHeaterClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        self._client = BleakClient(
+        client = BleakClient(
             self._address,
             disconnected_callback=self._on_disconnect,
         )
-        await self._client.connect()
-        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._client = client
+        try:
+            await client.connect()
+            await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        except Exception:
+            # Disconnect before re-raising so BlueZ releases this connection and
+            # any stale notification subscription — prevents "Notify acquired" on
+            # the next attempt.
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+            raise
         self._connected = True
         self._queue_task = asyncio.create_task(self._queue_runner())
         _LOGGER.info("Connected to %s", self._address)
@@ -288,6 +299,11 @@ class VelitHeaterClient:
 
     def _on_disconnect(self, _client: BleakClient) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
+        if not self._connected:
+            # The disconnect fired during a failed connect() attempt —
+            # _connected was never set True. connect() handles its own cleanup;
+            # do not start a reconnect loop here.
+            return
         self._connected = False
         _LOGGER.warning("Connection lost to %s", self._address)
         # Cancel any in-flight command future so the caller does not hang.

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -129,7 +129,6 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         key="fault_code",
         data_key="fault_name",
         name="Fault",
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     VelitSensorEntityDescription(
         key="machine_state",

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from homeassistant.components.climate import HVACMode
+from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import UnitOfTemperature
 
 from custom_components.velit.climate import (
@@ -137,6 +137,40 @@ class TestHeaterClimateState:
     def test_fan_mode(self):
         entity, _ = _heater_entity()
         assert entity.fan_mode == "3"
+
+    def test_hvac_action_heating_when_normal(self):
+        data = {**_make_heater_coord().data, "machine_state": 1, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.HEATING
+
+    def test_hvac_action_fan_when_cooling_down(self):
+        data = {**_make_heater_coord().data, "machine_state": 2, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.FAN
+
+    def test_hvac_action_idle_when_standby(self):
+        data = {**_make_heater_coord().data, "machine_state": 0, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.IDLE
+
+    def test_hvac_action_off_when_fault_active(self):
+        data = {**_make_heater_coord().data, "machine_state": 0, "fault_code": 1}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.OFF
+
+    def test_hvac_action_none_when_no_data(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.hvac_action is None
+
+    def test_extra_state_attributes_contains_machine_state_and_fault(self):
+        entity, _ = _heater_entity()
+        attrs = entity.extra_state_attributes
+        assert attrs["machine_state"] == "Normal"
+        assert attrs["fault"] == "No Fault"
+
+    def test_extra_state_attributes_empty_when_no_data(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.extra_state_attributes == {}
 
     def test_none_data_returns_none(self):
         entity, _ = _heater_entity(data=None)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -192,11 +192,6 @@ class TestHeaterClimateActions:
         coord._client.send_command.assert_called_once_with(0x02, bytes([0x00]))
         coord.async_request_refresh.assert_called_once()
 
-    async def test_set_hvac_fan_only(self):
-        entity, coord = _heater_entity()
-        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
-        coord._client.send_command.assert_called_once_with(0x03, bytes([0x00]))
-
     async def test_set_hvac_heat_manual(self):
         entity, coord = _heater_entity()
         await entity.async_set_hvac_mode(HVACMode.HEAT)


### PR DESCRIPTION
## Summary

- Maps heater machine states to `hvac_action` (HEATING / FAN / IDLE / OFF on fault) so the climate card shows active state without needing extra sensors
- Adds `extra_state_attributes` to the climate entity exposing `machine_state` and `fault` strings for automations
- Promotes fault sensor out of diagnostics so it appears prominently on the device page
- Fixes orphaned BLE connections on HA restart: `connect()` now disconnects before re-raising on failed `start_notify()`, and `_on_disconnect()` returns early if never fully connected — eliminates the "Notify acquired" storm on restart

## Test plan

- [ ] Climate card shows correct hvac_action during heating, cooling down, and fault states
- [ ] `machine_state` and `fault` visible in entity attributes panel
- [ ] Fault sensor appears on device page outside diagnostics
- [ ] HA restart produces clean single connect attempt with no "Notify acquired" errors

**Merge after:** feature/coordinator-entities
**Merge before:** feature/button-entities