### PR TITLE
Add fuel pump prime and cleaning button entities

### DIFF
--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -14,7 +14,7 @@ from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.CLIMATE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/velit/ac_client.py
+++ b/custom_components/velit/ac_client.py
@@ -178,12 +178,23 @@ class VelitACClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        self._client = BleakClient(
+        client = BleakClient(
             self._address,
             disconnected_callback=self._on_disconnect,
         )
-        await self._client.connect()
-        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._client = client
+        try:
+            await client.connect()
+            await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        except Exception:
+            # Disconnect before re-raising so BlueZ releases this connection and
+            # any stale notification subscription — prevents "Notify acquired" on
+            # the next attempt.
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+            raise
         self._connected = True
         self.unavailable = False
         self._consecutive_failures = 0
@@ -342,6 +353,11 @@ class VelitACClient:
 
     def _on_disconnect(self, _client: BleakClient) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
+        if not self._connected:
+            # The disconnect fired during a failed connect() attempt —
+            # _connected was never set True. connect() handles its own cleanup;
+            # do not start a reconnect loop here.
+            return
         self._connected = False
         _LOGGER.warning("Connection lost to %s", self._address)
         if self._pending and not self._pending.done():

--- a/custom_components/velit/button.py
+++ b/custom_components/velit/button.py
@@ -1,0 +1,135 @@
+"""Button entities for Velit heater devices.
+
+Exposes one-shot and toggled maintenance commands as HA button entities.
+These are diagnostic/advanced controls not needed for normal operation.
+
+Buttons:
+  VelitHeaterPrimeFuelPumpButton  — starts fuel pump (0x05), auto-stops after
+      30 seconds (0x06). Pressing again while priming stops it immediately,
+      mirroring the single-button behaviour on the physical hardware interface.
+  VelitHeaterCleaningButton       — triggers residual fuel clearance (0x09),
+      a one-shot command with no stop counterpart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DEVICE_TYPE_HEATER, DOMAIN
+from .coordinator import VelitHeaterCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Duration in seconds before the prime sequence auto-stops, matching the
+# default behaviour of the physical hardware button.
+_PRIME_AUTO_STOP_SECONDS = 30
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Velit button entities from a config entry."""
+    if entry.data["device_type"] != DEVICE_TYPE_HEATER:
+        return
+
+    coordinator: VelitHeaterCoordinator = entry.runtime_data
+    async_add_entities([
+        VelitHeaterPrimeFuelPumpButton(coordinator, entry),
+        VelitHeaterCleaningButton(coordinator, entry),
+    ])
+
+
+class VelitHeaterPrimeFuelPumpButton(
+    CoordinatorEntity[VelitHeaterCoordinator], ButtonEntity
+):
+    """Prime the fuel pump.
+
+    First press sends func 0x05 (start pump) and schedules an automatic stop
+    (func 0x06) after 30 seconds. Pressing again while priming cancels the
+    scheduled stop and sends 0x06 immediately, matching the physical interface.
+    """
+
+    _attr_name = "Prime Fuel Pump"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:fuel"
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_prime_fuel_pump"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+        self._prime_task: asyncio.Task | None = None
+
+    async def async_press(self) -> None:
+        """Handle button press — start or stop priming."""
+        if self._prime_task and not self._prime_task.done():
+            # Already priming — cancel the scheduled stop and stop immediately.
+            self._prime_task.cancel()
+            self._prime_task = None
+            await self.coordinator._client.send_command(0x06, bytes([0x00]))
+            _LOGGER.debug("Fuel pump prime stopped early by user")
+            return
+
+        # Start priming and schedule auto-stop.
+        await self.coordinator._client.send_command(0x05, bytes([0x00]))
+        _LOGGER.debug(
+            "Fuel pump prime started; auto-stop in %ds", _PRIME_AUTO_STOP_SECONDS
+        )
+        self._prime_task = asyncio.create_task(self._auto_stop())
+
+    async def _auto_stop(self) -> None:
+        """Wait then send stop command; cancelled if user presses early."""
+        await asyncio.sleep(_PRIME_AUTO_STOP_SECONDS)
+        await self.coordinator._client.send_command(0x06, bytes([0x00]))
+        self._prime_task = None
+        _LOGGER.debug("Fuel pump prime auto-stopped after %ds", _PRIME_AUTO_STOP_SECONDS)
+
+
+class VelitHeaterCleaningButton(
+    CoordinatorEntity[VelitHeaterCoordinator], ButtonEntity
+):
+    """Trigger residual fuel clearance (cleaning mode).
+
+    Sends func 0x09 — a one-shot command that purges residual fuel from the
+    system. No stop command is required; the device manages the sequence.
+    """
+
+    _attr_name = "Clean (Residual Fuel Clearance)"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:broom"
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_cleaning"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+
+    async def async_press(self) -> None:
+        """Send the residual fuel clearance command."""
+        await self.coordinator._client.send_command(0x09, bytes([0x00]))
+        _LOGGER.debug("Residual fuel clearance command sent")

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -82,9 +82,8 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     """Climate entity for a Velit heater (protocol V1.02).
 
     HVAC modes:
-      OFF       — heater is shut down
-      HEAT      — heater running (manual or thermostat preset)
-      FAN_ONLY  — ventilation only (func 0x03 / 0x04)
+      OFF   — heater is shut down
+      HEAT  — heater running (manual or thermostat preset)
 
     Presets (only meaningful in HEAT mode):
       manual      — fixed gear, no thermostat
@@ -93,7 +92,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     Fan modes: gear levels 1–5 (only meaningful in manual mode).
     """
 
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.FAN_ONLY]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
     _attr_preset_modes = ["manual", "thermostat"]
     _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -132,10 +131,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         state = self.coordinator.data["machine_state"]
         if state == 0:
             return HVACMode.OFF
-        work_mode = self.coordinator.data["work_mode"]
-        # Gear 0 with no work mode implies ventilation only.
-        if work_mode == 0:
-            return HVACMode.FAN_ONLY
         return HVACMode.HEAT
 
     @property
@@ -203,8 +198,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator._client.send_command(0x02, bytes([0x00]))
-        elif hvac_mode == HVACMode.FAN_ONLY:
-            await self.coordinator._client.send_command(0x03, bytes([0x00]))
         elif hvac_mode == HVACMode.HEAT:
             # Start in the currently selected preset mode.
             mode_byte = (

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -17,6 +17,7 @@ from typing import Any
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -163,6 +164,37 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         if self.coordinator.data is None:
             return None
         return str(self.coordinator.data["current_gear"])
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Current action shown on the climate card.
+
+        Maps machine state and fault code to an HVACAction so the climate card
+        reflects what the device is doing, not just what mode it is set to.
+        """
+        if self.coordinator.data is None:
+            return None
+        # Any active fault — device is not operational.
+        if self.coordinator.data["fault_code"] != 0:
+            return HVACAction.OFF
+        state = self.coordinator.data["machine_state"]
+        if state == 1:
+            return HVACAction.HEATING
+        if state == 2:
+            # Fan running to cool combustion chamber after shutdown.
+            return HVACAction.FAN
+        # Standby, overtemp standby, cleaning, clean complete — no active output.
+        return HVACAction.IDLE
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose machine state and fault as automation-accessible attributes."""
+        if self.coordinator.data is None:
+            return {}
+        return {
+            "machine_state": self.coordinator.data.get("machine_state_str"),
+            "fault": self.coordinator.data.get("fault_name"),
+        }
 
     # ------------------------------------------------------------------
     # Actions — send command then refresh to confirm state

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -181,8 +181,6 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
         if q2 is None:
             raise UpdateFailed("No response to Query 2 (0x0B)")
 
-        _LOGGER.debug("Q1 raw data: %s", q1["data"].hex())
-        _LOGGER.debug("Q2 raw data: %s", q2["data"].hex())
         return self._parse(q1["data"], q2["data"])
 
     def _parse(self, q1_data: bytes, q2_data: bytes) -> dict:

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -181,6 +181,8 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
         if q2 is None:
             raise UpdateFailed("No response to Query 2 (0x0B)")
 
+        _LOGGER.debug("Q1 raw data: %s", q1["data"].hex())
+        _LOGGER.debug("Q2 raw data: %s", q2["data"].hex())
         return self._parse(q1["data"], q2["data"])
 
     def _parse(self, q1_data: bytes, q2_data: bytes) -> dict:

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -182,12 +182,23 @@ class VelitHeaterClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        self._client = BleakClient(
+        client = BleakClient(
             self._address,
             disconnected_callback=self._on_disconnect,
         )
-        await self._client.connect()
-        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._client = client
+        try:
+            await client.connect()
+            await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        except Exception:
+            # Disconnect before re-raising so BlueZ releases this connection and
+            # any stale notification subscription — prevents "Notify acquired" on
+            # the next attempt.
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+            raise
         self._connected = True
         self._queue_task = asyncio.create_task(self._queue_runner())
         _LOGGER.info("Connected to %s", self._address)
@@ -288,6 +299,11 @@ class VelitHeaterClient:
 
     def _on_disconnect(self, _client: BleakClient) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
+        if not self._connected:
+            # The disconnect fired during a failed connect() attempt —
+            # _connected was never set True. connect() handles its own cleanup;
+            # do not start a reconnect loop here.
+            return
         self._connected = False
         _LOGGER.warning("Connection lost to %s", self._address)
         # Cancel any in-flight command future so the caller does not hang.

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -7,6 +7,8 @@ Heater sensors (all sourced from coordinator data):
   - Supply voltage
   - Fan RPM
   - Altitude
+  - Fuel pump frequency (Hz)
+  - Heater power (W)
   - Fault code (human-readable string)
   - Machine state (human-readable string)
 
@@ -32,6 +34,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
     UnitOfElectricPotential,
+    UnitOfFrequency,
+    UnitOfPower,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -101,6 +105,24 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         # Unit depends on the device's active temperature unit (metric vs imperial).
         # Set dynamically in VelitHeaterSensorEntity based on coordinator.temp_unit.
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="fuel_pump_freq",
+        data_key="fuel_pump_hz",
+        name="Fuel Pump Frequency",
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="heater_power",
+        data_key="heater_power_w",
+        name="Heater Power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     VelitSensorEntityDescription(

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -129,7 +129,6 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         key="fault_code",
         data_key="fault_name",
         name="Fault",
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     VelitSensorEntityDescription(
         key="machine_state",

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -42,6 +42,14 @@
     }
   },
   "entity": {
+    "button": {
+      "prime_fuel_pump": {
+        "name": "Prime Fuel Pump"
+      },
+      "cleaning": {
+        "name": "Clean (Residual Fuel Clearance)"
+      }
+    },
     "sensor": {
       "inlet_temp": {
         "name": "Inlet Temperature"
@@ -60,6 +68,12 @@
       },
       "altitude": {
         "name": "Altitude"
+      },
+      "fuel_pump_freq": {
+        "name": "Fuel Pump Frequency"
+      },
+      "heater_power": {
+        "name": "Heater Power"
       },
       "fault_code": {
         "name": "Fault"

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -42,6 +42,14 @@
     }
   },
   "entity": {
+    "button": {
+      "prime_fuel_pump": {
+        "name": "Prime Fuel Pump"
+      },
+      "cleaning": {
+        "name": "Clean (Residual Fuel Clearance)"
+      }
+    },
     "sensor": {
       "inlet_temp": {
         "name": "Inlet Temperature"
@@ -60,6 +68,12 @@
       },
       "altitude": {
         "name": "Altitude"
+      },
+      "fuel_pump_freq": {
+        "name": "Fuel Pump Frequency"
+      },
+      "heater_power": {
+        "name": "Heater Power"
       },
       "fault_code": {
         "name": "Fault"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,158 @@
+"""Unit tests for VelitHeaterPrimeFuelPumpButton and VelitHeaterCleaningButton.
+
+Coordinator client is mocked — tests verify correct commands are sent and that
+the prime toggle logic (start / auto-stop / early-stop) behaves as expected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from custom_components.velit.button import (
+    VelitHeaterCleaningButton,
+    VelitHeaterPrimeFuelPumpButton,
+    _PRIME_AUTO_STOP_SECONDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(address="AA:BB:CC:DD:EE:FF"):
+    entry = MagicMock()
+    entry.data = {"device_type": "heater", "address": address, "name": "Test Heater"}
+    return entry
+
+
+def _make_coord():
+    coord = MagicMock()
+    coord._client = MagicMock()
+    coord._client.send_command = AsyncMock()
+    return coord
+
+
+def _make_prime_button():
+    coord = _make_coord()
+    entry = _make_entry()
+    button = VelitHeaterPrimeFuelPumpButton(coord, entry)
+    return button, coord
+
+
+def _make_cleaning_button():
+    coord = _make_coord()
+    entry = _make_entry()
+    button = VelitHeaterCleaningButton(coord, entry)
+    return button, coord
+
+
+# ---------------------------------------------------------------------------
+# Prime button — start and auto-stop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prime_sends_start_command():
+    button, coord = _make_prime_button()
+    with patch("asyncio.create_task") as mock_task:
+        await button.async_press()
+    coord._client.send_command.assert_awaited_once_with(0x05, bytes([0x00]))
+
+
+@pytest.mark.asyncio
+async def test_prime_creates_auto_stop_task():
+    button, coord = _make_prime_button()
+    with patch("asyncio.create_task") as mock_task:
+        await button.async_press()
+    mock_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_prime_auto_stop_sends_stop_command():
+    button, coord = _make_prime_button()
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await button._auto_stop()
+    coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
+
+
+@pytest.mark.asyncio
+async def test_prime_auto_stop_clears_task_reference():
+    button, coord = _make_prime_button()
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await button._auto_stop()
+    assert button._prime_task is None
+
+
+# ---------------------------------------------------------------------------
+# Prime button — early stop (press again while priming)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prime_early_stop_cancels_task_and_sends_stop():
+    button, coord = _make_prime_button()
+
+    # Simulate an in-progress prime task.
+    mock_task = MagicMock(spec=asyncio.Task)
+    mock_task.done.return_value = False
+    button._prime_task = mock_task
+
+    await button.async_press()
+
+    mock_task.cancel.assert_called_once()
+    coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
+
+
+@pytest.mark.asyncio
+async def test_prime_early_stop_clears_task_reference():
+    button, coord = _make_prime_button()
+
+    mock_task = MagicMock(spec=asyncio.Task)
+    mock_task.done.return_value = False
+    button._prime_task = mock_task
+
+    await button.async_press()
+
+    assert button._prime_task is None
+
+
+@pytest.mark.asyncio
+async def test_prime_press_after_completed_task_starts_new_prime():
+    """A completed (done) task is not treated as in-progress."""
+    button, coord = _make_prime_button()
+
+    completed_task = MagicMock(spec=asyncio.Task)
+    completed_task.done.return_value = True
+    button._prime_task = completed_task
+
+    with patch("asyncio.create_task"):
+        await button.async_press()
+
+    # Should have started, not stopped.
+    coord._client.send_command.assert_awaited_once_with(0x05, bytes([0x00]))
+
+
+# ---------------------------------------------------------------------------
+# Cleaning button
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cleaning_sends_correct_command():
+    button, coord = _make_cleaning_button()
+    await button.async_press()
+    coord._client.send_command.assert_awaited_once_with(0x09, bytes([0x00]))
+
+
+# ---------------------------------------------------------------------------
+# Entity metadata
+# ---------------------------------------------------------------------------
+
+def test_prime_button_unique_id():
+    button, _ = _make_prime_button()
+    assert button.unique_id == "AA:BB:CC:DD:EE:FF_prime_fuel_pump"
+
+
+def test_cleaning_button_unique_id():
+    button, _ = _make_cleaning_button()
+    assert button.unique_id == "AA:BB:CC:DD:EE:FF_cleaning"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from homeassistant.components.climate import HVACMode
+from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import UnitOfTemperature
 
 from custom_components.velit.climate import (
@@ -137,6 +137,40 @@ class TestHeaterClimateState:
     def test_fan_mode(self):
         entity, _ = _heater_entity()
         assert entity.fan_mode == "3"
+
+    def test_hvac_action_heating_when_normal(self):
+        data = {**_make_heater_coord().data, "machine_state": 1, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.HEATING
+
+    def test_hvac_action_fan_when_cooling_down(self):
+        data = {**_make_heater_coord().data, "machine_state": 2, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.FAN
+
+    def test_hvac_action_idle_when_standby(self):
+        data = {**_make_heater_coord().data, "machine_state": 0, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.IDLE
+
+    def test_hvac_action_off_when_fault_active(self):
+        data = {**_make_heater_coord().data, "machine_state": 0, "fault_code": 1}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.OFF
+
+    def test_hvac_action_none_when_no_data(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.hvac_action is None
+
+    def test_extra_state_attributes_contains_machine_state_and_fault(self):
+        entity, _ = _heater_entity()
+        attrs = entity.extra_state_attributes
+        assert attrs["machine_state"] == "Normal"
+        assert attrs["fault"] == "No Fault"
+
+    def test_extra_state_attributes_empty_when_no_data(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.extra_state_attributes == {}
 
     def test_none_data_returns_none(self):
         entity, _ = _heater_entity(data=None)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -192,11 +192,6 @@ class TestHeaterClimateActions:
         coord._client.send_command.assert_called_once_with(0x02, bytes([0x00]))
         coord.async_request_refresh.assert_called_once()
 
-    async def test_set_hvac_fan_only(self):
-        entity, coord = _heater_entity()
-        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
-        coord._client.send_command.assert_called_once_with(0x03, bytes([0x00]))
-
     async def test_set_hvac_heat_manual(self):
         entity, coord = _heater_entity()
         await entity.async_set_hvac_mode(HVACMode.HEAT)


### PR DESCRIPTION
## Summary

- Adds `VelitHeaterPrimeFuelPumpButton` (0x05 start / 0x06 stop, 30s auto-stop matching hardware behaviour) and `VelitHeaterCleaningButton` (0x09 one-shot residual fuel clearance)
- Adds Fuel Pump Frequency (Hz) and Heater Power (W) sensors — both already parsed by the coordinator, not yet exposed
- 10 new tests; full suite passing

## Test plan

- [ ] Prime button starts fuel pump, auto-stops after 30s
- [ ] Prime button stops early when pressed again during a cycle
- [ ] Cleaning button triggers residual fuel clearance; machine_state transitions to Cleaning (4) then Clean Complete (5)
- [ ] Fuel pump frequency and heater power sensors show expected values during operation

**Merge after:** feature/heater-state-feedback
**Merge before:** feature/fault-surfacing