### PR TITLE
Replace fuel pump prime button with switch and countdown sensor

### DIFF
--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 
 from .const import DEVICE_TYPE_HEATER
 from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
@@ -28,6 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     if entry.data["device_type"] == DEVICE_TYPE_HEATER:
         coordinator = VelitHeaterCoordinator(hass, entry)
+        _remove_stale_entities(hass, entry)
     else:
         coordinator = VelitACCoordinator(hass, entry)
 
@@ -54,6 +56,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ))
 
     return True
+
+
+def _remove_stale_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove entity registry entries that no longer exist in the integration.
+
+    Called on every setup so upgrades from older versions clean up automatically.
+    Add entries here whenever an entity is removed or renamed between releases.
+    """
+    registry = er.async_get(hass)
+    address = entry.data["address"]
+
+    # Fuel pump prime was a button in earlier versions; replaced by a switch.
+    stale = registry.async_get_entity_id("button", entry.domain, f"{address}_prime_fuel_pump")
+    if stale:
+        registry.async_remove(stale)
+        _LOGGER.debug("Removed stale entity %s from registry", stale)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/velit/button.py
+++ b/custom_components/velit/button.py
@@ -1,19 +1,18 @@
 """Button entities for Velit heater devices.
 
-Exposes one-shot and toggled maintenance commands as HA button entities.
-These are diagnostic/advanced controls not needed for normal operation.
+Exposes one-shot maintenance commands as HA button entities.
 
 Buttons:
-  VelitHeaterPrimeFuelPumpButton  — starts fuel pump (0x05), auto-stops after
-      30 seconds (0x06). Pressing again while priming stops it immediately,
-      mirroring the single-button behaviour on the physical hardware interface.
-  VelitHeaterCleaningButton       — triggers residual fuel clearance (0x09),
-      a one-shot command with no stop counterpart.
+  VelitHeaterCleaningButton  — triggers residual fuel clearance (0x09),
+      a one-shot command; the device manages the cycle and reports progress
+      via machine_state (4 = Cleaning, 5 = Clean Complete).
+
+Note: Fuel pump priming was a button but is now a switch entity in switch.py
+to provide on/off state and a companion countdown sensor.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from homeassistant.components.button import ButtonEntity
@@ -29,10 +28,6 @@ from .coordinator import VelitHeaterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Duration in seconds before the prime sequence auto-stops, matching the
-# default behaviour of the physical hardware button.
-_PRIME_AUTO_STOP_SECONDS = 30
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -44,63 +39,7 @@ async def async_setup_entry(
         return
 
     coordinator: VelitHeaterCoordinator = entry.runtime_data
-    async_add_entities([
-        VelitHeaterPrimeFuelPumpButton(coordinator, entry),
-        VelitHeaterCleaningButton(coordinator, entry),
-    ])
-
-
-class VelitHeaterPrimeFuelPumpButton(
-    CoordinatorEntity[VelitHeaterCoordinator], ButtonEntity
-):
-    """Prime the fuel pump.
-
-    First press sends func 0x05 (start pump) and schedules an automatic stop
-    (func 0x06) after 30 seconds. Pressing again while priming cancels the
-    scheduled stop and sends 0x06 immediately, matching the physical interface.
-    """
-
-    _attr_name = "Prime Fuel Pump"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_icon = "mdi:fuel"
-
-    def __init__(
-        self,
-        coordinator: VelitHeaterCoordinator,
-        entry: ConfigEntry,
-    ) -> None:
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{entry.data['address']}_prime_fuel_pump"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data["address"])},
-            name=entry.data.get(CONF_NAME, entry.data["address"]),
-            manufacturer="Velit",
-        )
-        self._prime_task: asyncio.Task | None = None
-
-    async def async_press(self) -> None:
-        """Handle button press — start or stop priming."""
-        if self._prime_task and not self._prime_task.done():
-            # Already priming — cancel the scheduled stop and stop immediately.
-            self._prime_task.cancel()
-            self._prime_task = None
-            await self.coordinator._client.send_command(0x06, bytes([0x00]))
-            _LOGGER.debug("Fuel pump prime stopped early by user")
-            return
-
-        # Start priming and schedule auto-stop.
-        await self.coordinator._client.send_command(0x05, bytes([0x00]))
-        _LOGGER.debug(
-            "Fuel pump prime started; auto-stop in %ds", _PRIME_AUTO_STOP_SECONDS
-        )
-        self._prime_task = asyncio.create_task(self._auto_stop())
-
-    async def _auto_stop(self) -> None:
-        """Wait then send stop command; cancelled if user presses early."""
-        await asyncio.sleep(_PRIME_AUTO_STOP_SECONDS)
-        await self.coordinator._client.send_command(0x06, bytes([0x00]))
-        self._prime_task = None
-        _LOGGER.debug("Fuel pump prime auto-stopped after %ds", _PRIME_AUTO_STOP_SECONDS)
+    async_add_entities([VelitHeaterCleaningButton(coordinator, entry)])
 
 
 class VelitHeaterCleaningButton(

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -97,6 +97,20 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         self.domain = DOMAIN
         # Detected on first connect — preserved for the lifetime of the entry.
         self.temp_unit: str = UnitOfTemperature.CELSIUS
+        # Prime pump state — owned by VelitHeaterFuelPrimingSwitch, read by the
+        # countdown sensor. Stored here so both entities share it without coupling.
+        self.priming: bool = False
+        self.prime_remaining: int = 0
+        self._prime_tick_callbacks: list = []
+
+    def register_prime_tick(self, callback) -> None:
+        """Register a callback to fire on each prime countdown tick."""
+        self._prime_tick_callbacks.append(callback)
+
+    def _notify_prime_tick(self) -> None:
+        """Notify all registered prime tick listeners (e.g. countdown sensor)."""
+        for cb in self._prime_tick_callbacks:
+            cb()
 
     async def async_connect(self) -> None:
         """Connect the BLE client. Called from async_setup_entry."""

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -37,6 +37,7 @@ from homeassistant.const import (
     UnitOfFrequency,
     UnitOfPower,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -148,10 +149,11 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     if entry.data["device_type"] == DEVICE_TYPE_HEATER:
-        async_add_entities(
-            VelitHeaterSensorEntity(coordinator, entry, description)
-            for description in HEATER_SENSORS
-        )
+        async_add_entities([
+            *(VelitHeaterSensorEntity(coordinator, entry, description)
+              for description in HEATER_SENSORS),
+            VelitHeaterPrimeCountdownSensor(coordinator, entry),
+        ])
     else:
         async_add_entities([VelitACFaultSensorEntity(coordinator, entry)])
 
@@ -186,6 +188,42 @@ class VelitHeaterSensorEntity(CoordinatorEntity[VelitHeaterCoordinator], SensorE
         if self.coordinator.data is None:
             return None
         return self.coordinator.data.get(self.entity_description.data_key)
+
+
+class VelitHeaterPrimeCountdownSensor(SensorEntity):
+    """Counts down seconds remaining in the fuel pump prime cycle.
+
+    Updated every second by the prime switch's tick callbacks rather than by
+    the coordinator poll, so the display ticks in real time during the 30s
+    prime sequence. Reads prime state from the coordinator so it shares state
+    with the switch without any direct entity-to-entity coupling.
+    """
+
+    _attr_name = "Fuel Pump Prime Remaining"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:timer-outline"
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        self._coordinator = coordinator
+        self._attr_unique_id = f"{entry.data['address']}_prime_countdown"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+        # Register for per-second ticks from the prime switch.
+        coordinator.register_prime_tick(self.async_write_ha_state)
+
+    @property
+    def native_value(self) -> int:
+        return self._coordinator.prime_remaining
 
 
 class VelitACFaultSensorEntity(CoordinatorEntity[VelitACCoordinator], SensorEntity):

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -50,9 +50,6 @@
   },
   "entity": {
     "button": {
-      "prime_fuel_pump": {
-        "name": "Prime Fuel Pump"
-      },
       "cleaning": {
         "name": "Cleaning"
       }
@@ -60,6 +57,14 @@
     "switch": {
       "ble_connection": {
         "name": "BLE Connection"
+      },
+      "fuel_priming": {
+        "name": "Fuel Pump Prime"
+      }
+    },
+    "sensor": {
+      "prime_countdown": {
+        "name": "Fuel Pump Prime Remaining"
       }
     },
     "sensor": {

--- a/custom_components/velit/switch.py
+++ b/custom_components/velit/switch.py
@@ -13,11 +13,12 @@ AC:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -39,7 +40,10 @@ async def async_setup_entry(
         return
 
     coordinator: VelitHeaterCoordinator = entry.runtime_data
-    async_add_entities([VelitHeaterBLESwitch(coordinator, entry)])
+    async_add_entities([
+        VelitHeaterBLESwitch(coordinator, entry),
+        VelitHeaterFuelPrimingSwitch(coordinator, entry),
+    ])
 
 
 class VelitHeaterBLESwitch(CoordinatorEntity[VelitHeaterCoordinator], SwitchEntity):
@@ -95,3 +99,82 @@ class VelitHeaterBLESwitch(CoordinatorEntity[VelitHeaterCoordinator], SwitchEnti
         """Disconnect from the device and suppress automatic reconnection."""
         await self.coordinator._client.disconnect()
         self.async_write_ha_state()
+
+
+_PRIME_DURATION = 30  # seconds — matches physical hardware button auto-stop
+
+
+class VelitHeaterFuelPrimingSwitch(CoordinatorEntity[VelitHeaterCoordinator], SwitchEntity):
+    """Toggle switch for the fuel pump prime cycle.
+
+    On  — prime cycle running; auto-stops after 30 seconds.
+    Off — idle; turning off early sends the stop command immediately.
+
+    Prime state is stored on the coordinator so the companion countdown
+    sensor can read it without coupling directly to this entity.
+    """
+
+    _attr_name = "Fuel Pump Prime"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:fuel"
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_fuel_priming"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+        self._prime_task: asyncio.Task | None = None
+
+    @property
+    def available(self) -> bool:
+        # Readable and pressable whenever BLE is connected.
+        return self.coordinator._client.connected
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.priming
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Start the fuel pump prime cycle."""
+        if self.coordinator.priming:
+            return
+        await self.coordinator._client.send_command(0x05, bytes([0x00]))
+        self.coordinator.priming = True
+        self.coordinator.prime_remaining = _PRIME_DURATION
+        self._prime_task = asyncio.create_task(self._run_prime())
+        self.async_write_ha_state()
+        self.coordinator._notify_prime_tick()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Stop the prime cycle early — cancels the task which sends the stop command."""
+        if not self.coordinator.priming:
+            return
+        if self._prime_task and not self._prime_task.done():
+            self._prime_task.cancel()
+
+    async def _run_prime(self) -> None:
+        """Countdown task — ticks every second, sends stop on completion or cancellation."""
+        try:
+            while self.coordinator.prime_remaining > 0:
+                await asyncio.sleep(1)
+                self.coordinator.prime_remaining -= 1
+                self.async_write_ha_state()
+                self.coordinator._notify_prime_tick()
+            await self.coordinator._client.send_command(0x06, bytes([0x00]))
+            _LOGGER.debug("Fuel pump prime auto-stopped after %ds", _PRIME_DURATION)
+        except asyncio.CancelledError:
+            await self.coordinator._client.send_command(0x06, bytes([0x00]))
+            _LOGGER.debug("Fuel pump prime stopped early by user")
+        finally:
+            self.coordinator.priming = False
+            self.coordinator.prime_remaining = 0
+            self._prime_task = None
+            self.async_write_ha_state()
+            self.coordinator._notify_prime_tick()

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -50,9 +50,6 @@
   },
   "entity": {
     "button": {
-      "prime_fuel_pump": {
-        "name": "Prime Fuel Pump"
-      },
       "cleaning": {
         "name": "Cleaning"
       }
@@ -60,6 +57,14 @@
     "switch": {
       "ble_connection": {
         "name": "BLE Connection"
+      },
+      "fuel_priming": {
+        "name": "Fuel Pump Prime"
+      }
+    },
+    "sensor": {
+      "prime_countdown": {
+        "name": "Fuel Pump Prime Remaining"
       }
     },
     "sensor": {

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,21 +1,12 @@
-"""Unit tests for VelitHeaterPrimeFuelPumpButton and VelitHeaterCleaningButton.
-
-Coordinator client is mocked — tests verify correct commands are sent and that
-the prime toggle logic (start / auto-stop / early-stop) behaves as expected.
-"""
+"""Unit tests for VelitHeaterCleaningButton."""
 
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.velit.button import (
-    VelitHeaterCleaningButton,
-    VelitHeaterPrimeFuelPumpButton,
-    _PRIME_AUTO_STOP_SECONDS,
-)
+from custom_components.velit.button import VelitHeaterCleaningButton
 
 
 # ---------------------------------------------------------------------------
@@ -35,102 +26,11 @@ def _make_coord():
     return coord
 
 
-def _make_prime_button():
-    coord = _make_coord()
-    entry = _make_entry()
-    button = VelitHeaterPrimeFuelPumpButton(coord, entry)
-    return button, coord
-
-
 def _make_cleaning_button():
     coord = _make_coord()
     entry = _make_entry()
     button = VelitHeaterCleaningButton(coord, entry)
     return button, coord
-
-
-# ---------------------------------------------------------------------------
-# Prime button — start and auto-stop
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_prime_sends_start_command():
-    button, coord = _make_prime_button()
-    with patch("asyncio.create_task") as mock_task:
-        await button.async_press()
-    coord._client.send_command.assert_awaited_once_with(0x05, bytes([0x00]))
-
-
-@pytest.mark.asyncio
-async def test_prime_creates_auto_stop_task():
-    button, coord = _make_prime_button()
-    with patch("asyncio.create_task") as mock_task:
-        await button.async_press()
-    mock_task.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_prime_auto_stop_sends_stop_command():
-    button, coord = _make_prime_button()
-    with patch("asyncio.sleep", new_callable=AsyncMock):
-        await button._auto_stop()
-    coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
-
-
-@pytest.mark.asyncio
-async def test_prime_auto_stop_clears_task_reference():
-    button, coord = _make_prime_button()
-    with patch("asyncio.sleep", new_callable=AsyncMock):
-        await button._auto_stop()
-    assert button._prime_task is None
-
-
-# ---------------------------------------------------------------------------
-# Prime button — early stop (press again while priming)
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_prime_early_stop_cancels_task_and_sends_stop():
-    button, coord = _make_prime_button()
-
-    # Simulate an in-progress prime task.
-    mock_task = MagicMock(spec=asyncio.Task)
-    mock_task.done.return_value = False
-    button._prime_task = mock_task
-
-    await button.async_press()
-
-    mock_task.cancel.assert_called_once()
-    coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
-
-
-@pytest.mark.asyncio
-async def test_prime_early_stop_clears_task_reference():
-    button, coord = _make_prime_button()
-
-    mock_task = MagicMock(spec=asyncio.Task)
-    mock_task.done.return_value = False
-    button._prime_task = mock_task
-
-    await button.async_press()
-
-    assert button._prime_task is None
-
-
-@pytest.mark.asyncio
-async def test_prime_press_after_completed_task_starts_new_prime():
-    """A completed (done) task is not treated as in-progress."""
-    button, coord = _make_prime_button()
-
-    completed_task = MagicMock(spec=asyncio.Task)
-    completed_task.done.return_value = True
-    button._prime_task = completed_task
-
-    with patch("asyncio.create_task"):
-        await button.async_press()
-
-    # Should have started, not stopped.
-    coord._client.send_command.assert_awaited_once_with(0x05, bytes([0x00]))
 
 
 # ---------------------------------------------------------------------------
@@ -142,15 +42,6 @@ async def test_cleaning_sends_correct_command():
     button, coord = _make_cleaning_button()
     await button.async_press()
     coord._client.send_command.assert_awaited_once_with(0x09, bytes([0x00]))
-
-
-# ---------------------------------------------------------------------------
-# Entity metadata
-# ---------------------------------------------------------------------------
-
-def test_prime_button_unique_id():
-    button, _ = _make_prime_button()
-    assert button.unique_id == "AA:BB:CC:DD:EE:FF_prime_fuel_pump"
 
 
 def test_cleaning_button_unique_id():

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,12 +1,17 @@
-"""Unit tests for VelitHeaterBLESwitch."""
+"""Unit tests for VelitHeaterBLESwitch and VelitHeaterFuelPrimingSwitch."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.velit.switch import VelitHeaterBLESwitch
+from custom_components.velit.switch import (
+    VelitHeaterBLESwitch,
+    VelitHeaterFuelPrimingSwitch,
+    _PRIME_DURATION,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -99,3 +104,158 @@ class TestBLESwitchActions:
     def test_unique_id(self):
         entity, _ = _make_entity()
         assert entity._attr_unique_id == "AA:BB:CC:DD:EE:FF_ble_connection"
+
+
+# ---------------------------------------------------------------------------
+# Prime switch helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_prime_entity(connected=True):
+    coord = MagicMock()
+    coord._client = MagicMock()
+    coord._client.connected = connected
+    coord._client.send_command = AsyncMock()
+    coord.priming = False
+    coord.prime_remaining = 0
+    coord._notify_prime_tick = MagicMock()
+    entry = _make_entry()
+    entity = VelitHeaterFuelPrimingSwitch.__new__(VelitHeaterFuelPrimingSwitch)
+    entity.coordinator = coord
+    entity._attr_unique_id = f"{entry.data['address']}_fuel_priming"
+    entity._attr_device_info = MagicMock()
+    entity._prime_task = None
+    entity.async_write_ha_state = MagicMock()
+    return entity, coord
+
+
+# ---------------------------------------------------------------------------
+# Prime switch — state
+# ---------------------------------------------------------------------------
+
+
+class TestPrimeSwitchState:
+    def test_is_on_when_priming(self):
+        entity, coord = _make_prime_entity()
+        coord.priming = True
+        assert entity.is_on is True
+
+    def test_is_off_when_not_priming(self):
+        entity, coord = _make_prime_entity()
+        coord.priming = False
+        assert entity.is_on is False
+
+    def test_available_when_connected(self):
+        entity, _ = _make_prime_entity(connected=True)
+        assert entity.available is True
+
+    def test_unavailable_when_disconnected(self):
+        entity, _ = _make_prime_entity(connected=False)
+        assert entity.available is False
+
+    def test_unique_id(self):
+        entity, _ = _make_prime_entity()
+        assert entity._attr_unique_id == "AA:BB:CC:DD:EE:FF_fuel_priming"
+
+
+# ---------------------------------------------------------------------------
+# Prime switch — actions
+# ---------------------------------------------------------------------------
+
+
+class TestPrimeSwitchActions:
+    async def test_turn_on_sends_start_command(self):
+        entity, coord = _make_prime_entity()
+        with patch("asyncio.create_task"):
+            await entity.async_turn_on()
+        coord._client.send_command.assert_awaited_once_with(0x05, bytes([0x00]))
+
+    async def test_turn_on_sets_priming_state(self):
+        entity, coord = _make_prime_entity()
+        with patch("asyncio.create_task"):
+            await entity.async_turn_on()
+        assert coord.priming is True
+        assert coord.prime_remaining == _PRIME_DURATION
+
+    async def test_turn_on_notifies_tick(self):
+        entity, coord = _make_prime_entity()
+        with patch("asyncio.create_task"):
+            await entity.async_turn_on()
+        coord._notify_prime_tick.assert_called_once()
+
+    async def test_turn_on_is_noop_when_already_priming(self):
+        entity, coord = _make_prime_entity()
+        coord.priming = True
+        await entity.async_turn_on()
+        coord._client.send_command.assert_not_awaited()
+
+    async def test_turn_off_cancels_task(self):
+        entity, coord = _make_prime_entity()
+        coord.priming = True
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        entity._prime_task = mock_task
+        await entity.async_turn_off()
+        mock_task.cancel.assert_called_once()
+
+    async def test_turn_off_is_noop_when_not_priming(self):
+        entity, coord = _make_prime_entity()
+        mock_task = MagicMock()
+        entity._prime_task = mock_task
+        await entity.async_turn_off()
+        mock_task.cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Prime switch — countdown task
+# ---------------------------------------------------------------------------
+
+
+class TestPrimeSwitchRunPrime:
+    async def test_auto_stop_sends_stop_command(self):
+        entity, coord = _make_prime_entity()
+        coord.prime_remaining = 1
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await entity._run_prime()
+        coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
+
+    async def test_auto_stop_resets_state(self):
+        entity, coord = _make_prime_entity()
+        coord.prime_remaining = 1
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await entity._run_prime()
+        assert coord.priming is False
+        assert coord.prime_remaining == 0
+        assert entity._prime_task is None
+
+    async def test_cancelled_sends_stop_command(self):
+        entity, coord = _make_prime_entity()
+        coord.prime_remaining = 30
+        with patch("asyncio.sleep", side_effect=asyncio.CancelledError):
+            await entity._run_prime()
+        coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
+
+    async def test_cancelled_resets_state(self):
+        entity, coord = _make_prime_entity()
+        coord.prime_remaining = 30
+        with patch("asyncio.sleep", side_effect=asyncio.CancelledError):
+            await entity._run_prime()
+        assert coord.priming is False
+        assert coord.prime_remaining == 0
+        assert entity._prime_task is None
+
+    async def test_tick_decrements_remaining(self):
+        entity, coord = _make_prime_entity()
+        coord.prime_remaining = 2
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await entity._run_prime()
+        # After 2 ticks, prime_remaining should be 0 (finally sets it to 0)
+        assert coord.prime_remaining == 0
+
+    async def test_tick_notifies_on_each_step(self):
+        entity, coord = _make_prime_entity()
+        coord.prime_remaining = 2
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await entity._run_prime()
+        # 2 ticks during loop + 1 in finally = 3 total
+        assert coord._notify_prime_tick.call_count == 3


### PR DESCRIPTION
## Summary

- Fuel pump prime is now a switch with visible on/off state and 30s auto-stop matching hardware behaviour; turning off early sends the stop command immediately
- Companion countdown sensor ticks every second via coordinator callbacks — updates in real time during the prime cycle, independent of the 30s coordinator poll
- Prime state stored on the coordinator so the switch and sensor share it without direct entity coupling
- Stale `button.prime_fuel_pump` entity removed from the registry automatically on setup — no manual cleanup needed on existing installs
- 188 tests passing

## Test plan

- [ ] Prime switch shows on/off state correctly; countdown sensor ticks down from 30 in real time
- [ ] Auto-stop after 30s sends stop command and resets switch to off
- [ ] Manual off during cycle sends stop command immediately
- [ ] Upgrading from previous version: orphaned prime_fuel_pump button entity removed automatically on reload

**Merge after:** feature/fault-surfacing