### PR TITLE
Phase 0: integration scaffold, CI workflow, and project baseline

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,37 @@
+name: Validate
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  hassfest:
+    name: Validate with hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: Validate with HACS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration
+
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run tests
+        run: pytest tests/ -v

--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -1,0 +1,24 @@
+"""Velit heater and air conditioner integration for Home Assistant."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+# Populated in later phases as platforms are implemented.
+PLATFORMS: list[str] = []
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a Velit device from a config entry."""
+    # Full implementation added in coordinator and entity phases.
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Velit config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/velit/const.py
+++ b/custom_components/velit/const.py
@@ -1,0 +1,39 @@
+"""Constants for the Velit integration."""
+
+DOMAIN = "velit"
+
+# Device type identifiers stored in config entry data.
+# Determined during config flow — cannot be inferred from BLE advertisement alone (open question).
+DEVICE_TYPE_HEATER = "heater"
+DEVICE_TYPE_AC = "ac"
+
+# BLE characteristic UUIDs — shared across both heater and AC devices.
+# Source: Velit communication protocol documents V1.01 / V1.02.
+UUID_SERVICE = "0000ffe0-0000-1000-8000-00805f9b34fb"
+UUID_READ_NOTIFY = "0000ffe1-0000-1000-8000-00805f9b34fb"
+UUID_WRITE = "0000ffe2-0000-1000-8000-00805f9b34fb"
+
+# BLE advertisement local names observed for Velit devices.
+# Note: "D30" is a generic name — may match non-Velit devices. Requires hardware verification.
+BLE_LOCAL_NAMES = ["VELIT", "VLIT", "D30"]
+
+# Heater protocol constants (V1.02)
+HEATER_START_BYTE = 0x55
+HEATER_RESPONSE_START = 0xAA
+HEATER_MFG_CODE = bytes([0x53, 0x46])  # "SF" — validated in every heater response
+
+# AC protocol constants (V1.01)
+AC_START_BYTES = bytes([0x5A, 0x5A])
+AC_END_BYTES = bytes([0x0D, 0x0A])
+AC_COMMAND_INTERVAL_MS = 400  # minimum ms between commands per protocol spec
+AC_RESPONSE_TIMEOUT_S = 3     # seconds before a command is considered failed
+AC_MAX_RETRIES = 3            # attempts before marking device unavailable
+
+# Temperature encoding — both devices transmit hex values, not raw degrees.
+# C range: 16–30 displayed, 0x10–0x1E transmitted
+# F range: 61–86 displayed, 0x3D–0x56 transmitted
+# Formula: F = 1.8 * C + 32
+HEATER_MIN_TEMP_C = 16
+HEATER_MAX_TEMP_C = 30
+AC_MIN_TEMP_C = 17
+AC_MAX_TEMP_C = 30

--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -1,0 +1,17 @@
+{
+  "domain": "velit",
+  "name": "Velit",
+  "codeowners": ["@JohnFreeborg", "@jeremyroe"],
+  "config_flow": true,
+  "documentation": "https://github.com/JohnFreeborg/velit-hass",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/JohnFreeborg/velit-hass/issues",
+  "requirements": [],
+  "version": "0.0.1",
+  "bluetooth": [
+    {"local_name": "VELIT", "connectable": true},
+    {"local_name": "VLIT", "connectable": true},
+    {"local_name": "D30", "connectable": true}
+  ]
+}

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "title": "Add Velit Device",
+        "description": "Enter the Bluetooth address of your Velit device.",
+        "data": {
+          "address": "Bluetooth Address"
+        }
+      },
+      "bluetooth_confirm": {
+        "title": "Confirm Velit Device",
+        "description": "Set up {name}?"
+      },
+      "device_type": {
+        "title": "Select Device Type",
+        "description": "Is this device a heater or an air conditioner?",
+        "data": {
+          "device_type": "Device Type"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to device",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "This device is already configured",
+      "no_devices_found": "No Velit devices found nearby"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Velit Options",
+        "data": {
+          "poll_interval": "Poll interval (seconds)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "title": "Add Velit Device",
+        "description": "Enter the Bluetooth address of your Velit device.",
+        "data": {
+          "address": "Bluetooth Address"
+        }
+      },
+      "bluetooth_confirm": {
+        "title": "Confirm Velit Device",
+        "description": "Set up {name}?"
+      },
+      "device_type": {
+        "title": "Select Device Type",
+        "description": "Is this device a heater or an air conditioner?",
+        "data": {
+          "device_type": "Device Type"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to device",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "This device is already configured",
+      "no_devices_found": "No Velit devices found nearby"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Velit Options",
+        "data": {
+          "poll_interval": "Poll interval (seconds)"
+        }
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Velit",
+  "domains": ["velit"],
+  "documentation": "https://github.com/JohnFreeborg/velit-hass",
+  "homeassistant": "2024.1.0"
+}

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+pytest-homeassistant-custom-component
+pytest>=7.0
+pytest-cov
+syrupy
+ruff

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for the Velit integration.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+# Shared test fixtures for the Velit integration test suite.
+# Populated as platforms and coordinators are implemented in later phases.


### PR DESCRIPTION
## Summary

- Full integration directory structure under `custom_components/velit/`
- `manifest.json`: domain, codeowners, BT matchers (VELIT*/VLIT*/D30*), version 0.0.1
- `__init__.py`: stub `async_setup_entry` / `async_unload_entry`
- `const.py`: domain, device type constants, BLE UUIDs, protocol framing constants, temp ranges
- `hacs.json`: name, domains, documentation URL, HA minimum version
- `strings.json` + `translations/en.json`: config flow skeleton
- `.github/workflows/validate.yaml`: hassfest, hacs/action, pytest on Python 3.12
- `requirements_test.txt`: pytest-homeassistant-custom-component, pytest-cov, syrupy, ruff
- `tests/__init__.py` + `tests/conftest.py`: stubs
- `CONTRIBUTING.md`: branching, PR process, hardware validation requirement, commit style

**Merge before:** feature/packet-layer