### PR TITLE
Phase 2: BLE connection layer for heater and AC clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # Local development tooling — not for version control
 .claude/
+tools/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tools/
 __pycache__/
 *.pyc
 *.pyo
+.pytest_cache/
+.ruff_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@ __pycache__/
 *.pyo
 .pytest_cache/
 .ruff_cache/
+.mypy_cache/
+*.egg-info/
+dist/
+build/
+
+# Test output
+.coverage
+htmlcov/
+coverage.xml

--- a/custom_components/velit/ac_client.py
+++ b/custom_components/velit/ac_client.py
@@ -1,8 +1,7 @@
-"""AC BLE packet builder and response parser.
+"""AC BLE packet builder, response parser, and connection client.
 
 Protocol: Velit Air Conditioner Communication Protocol V1.01.
-This module handles packet construction and parsing only.
-BLE connection management is implemented separately.
+Packet construction, parsing, and BLE connection management are all here.
 
 Packet structure (command, app to AC):
   [0x5A][0x5A][length][product_code][func][data N][checksum 1B][0x0D][0x0A]
@@ -25,7 +24,21 @@ mark the device as unavailable.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
+from typing import Union
+
+from bleak import BleakClient, BLEDevice
+from bleak.backends.characteristic import BleakGATTCharacteristic
+
+from .const import (
+    AC_COMMAND_INTERVAL_MS,
+    AC_MAX_RETRIES,
+    AC_RESPONSE_TIMEOUT_S,
+    UUID_READ_NOTIFY,
+    UUID_WRITE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,3 +126,241 @@ def _validate_response_checksum(raw: bytes) -> bool:
     """
     expected = _ac_checksum(raw[:-3])
     return raw[-3] == expected
+
+
+# ---------------------------------------------------------------------------
+# BLE connection layer
+# ---------------------------------------------------------------------------
+
+_RECONNECT_DELAY_INITIAL = 1.0  # seconds
+_RECONNECT_DELAY_MAX = 30.0     # seconds
+_COMMAND_INTERVAL = AC_COMMAND_INTERVAL_MS / 1000.0  # convert to seconds
+
+
+class VelitACClient:
+    """BLE client for the Velit AC protocol (V1.01).
+
+    Manages connection, command serialisation, inter-command timing,
+    retry logic, and notification handling.
+
+    Timing rules per protocol spec:
+    - Minimum 400ms between commands.
+    - On no response within 3s, retry once.
+    - After AC_MAX_RETRIES consecutive failures, mark the device unavailable.
+    """
+
+    def __init__(
+        self,
+        address: Union[str, BLEDevice],
+        product_code: int = DEFAULT_PRODUCT_CODE,
+    ) -> None:
+        """
+        Args:
+            address:      BLE device address or BLEDevice from discovery.
+            product_code: 1-byte product identifier (default 0x01).
+        """
+        self._address = address
+        self._product_code = product_code
+        self._client: BleakClient | None = None
+        self._queue: asyncio.Queue[
+            tuple[int, bytes, asyncio.Future[dict | None]]
+        ] = asyncio.Queue()
+        self._pending: asyncio.Future[dict | None] | None = None
+        self._connected = False
+        self.unavailable = False
+        self._consecutive_failures = 0
+        self._last_command_time: float = 0.0
+        self._queue_task: asyncio.Task | None = None
+        self._reconnect_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """Connect to the device and subscribe to response notifications."""
+        self._client = BleakClient(
+            self._address,
+            disconnected_callback=self._on_disconnect,
+        )
+        await self._client.connect()
+        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._connected = True
+        self.unavailable = False
+        self._consecutive_failures = 0
+        self._queue_task = asyncio.ensure_future(self._queue_runner())
+        _LOGGER.info("Connected to %s", self._address)
+
+    async def disconnect(self) -> None:
+        """Disconnect cleanly, stopping the command queue first."""
+        self._connected = False
+
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+
+        if self._queue_task and not self._queue_task.done():
+            self._queue_task.cancel()
+
+        if self._client and self._client.is_connected:
+            try:
+                await self._client.stop_notify(UUID_READ_NOTIFY)
+            except Exception:
+                pass
+            await self._client.disconnect()
+
+        _LOGGER.info("Disconnected from %s", self._address)
+
+    async def send_command(
+        self,
+        func: int,
+        data: bytes,
+        timeout: float = float(AC_RESPONSE_TIMEOUT_S),
+    ) -> dict | None:
+        """Queue a command and wait for the parsed response.
+
+        Returns the parsed response dict, or None if the command failed or
+        timed out. The caller does not need to handle retry logic —
+        the queue runner applies one automatic retry per the protocol spec.
+        Returns None and sets self.unavailable = True after AC_MAX_RETRIES
+        consecutive failures.
+        """
+        if self.unavailable:
+            _LOGGER.debug("send_command skipped — device marked unavailable")
+            return None
+
+        if not self._connected:
+            _LOGGER.debug("send_command called while not connected")
+            return None
+
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[dict | None] = loop.create_future()
+        await self._queue.put((func, data, fut))
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout * 2 + _COMMAND_INTERVAL + 2.0)
+        except asyncio.TimeoutError:
+            _LOGGER.warning("send_command timed out (func 0x%02X)", func)
+            return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _queue_runner(self) -> None:
+        """Process commands one at a time, enforcing inter-command timing."""
+        while self._connected:
+            try:
+                func, data, caller_fut = await asyncio.wait_for(
+                    self._queue.get(), timeout=1.0
+                )
+            except asyncio.TimeoutError:
+                continue
+
+            result = await self._execute_with_retry(func, data)
+            self._queue.task_done()
+
+            if not caller_fut.done():
+                caller_fut.set_result(result)
+
+    async def _execute_with_retry(
+        self, func: int, data: bytes
+    ) -> dict | None:
+        """Send a command with one automatic retry per the protocol spec.
+
+        Returns the parsed response or None. Updates failure tracking and
+        sets self.unavailable if AC_MAX_RETRIES is reached.
+        """
+        for attempt in range(2):  # initial attempt + one retry
+            await self._enforce_interval()
+            result = await self._write_and_wait(func, data)
+
+            if result is not None:
+                self._consecutive_failures = 0
+                return result
+
+            if attempt == 0:
+                _LOGGER.debug(
+                    "No response for func 0x%02X, retrying once", func
+                )
+
+        # Both attempts failed.
+        self._consecutive_failures += 1
+        _LOGGER.warning(
+            "Command failed (func 0x%02X), consecutive failures: %d/%d",
+            func, self._consecutive_failures, AC_MAX_RETRIES,
+        )
+
+        if self._consecutive_failures >= AC_MAX_RETRIES:
+            self.unavailable = True
+            _LOGGER.error(
+                "Device at %s marked unavailable after %d consecutive failures",
+                self._address, self._consecutive_failures,
+            )
+
+        return None
+
+    async def _write_and_wait(self, func: int, data: bytes) -> dict | None:
+        """Write one command and wait up to AC_RESPONSE_TIMEOUT_S for a response."""
+        loop = asyncio.get_running_loop()
+        self._pending = loop.create_future()
+        result: dict | None = None
+
+        try:
+            packet = build_command(func, data, self._product_code)
+            await self._client.write_gatt_char(  # type: ignore[union-attr]
+                UUID_WRITE, packet, response=True
+            )
+            self._last_command_time = time.monotonic()
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.shield(self._pending),
+                    timeout=float(AC_RESPONSE_TIMEOUT_S),
+                )
+            except asyncio.TimeoutError:
+                pass
+        except Exception as exc:
+            _LOGGER.warning("Write failed (func 0x%02X): %s", func, exc)
+        finally:
+            self._pending = None
+
+        return result
+
+    async def _enforce_interval(self) -> None:
+        """Sleep until at least AC_COMMAND_INTERVAL_MS has elapsed since the last write."""
+        elapsed = time.monotonic() - self._last_command_time
+        wait = _COMMAND_INTERVAL - elapsed
+        if wait > 0:
+            await asyncio.sleep(wait)
+
+    def _on_notification(
+        self, _char: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle an incoming notification from the device."""
+        parsed = parse_response(bytes(data))
+        if self._pending and not self._pending.done():
+            self._pending.set_result(parsed)
+        elif parsed:
+            _LOGGER.debug("Unsolicited notification: func 0x%02X", parsed.get("func"))
+
+    def _on_disconnect(self, _client: BleakClient) -> None:
+        """Called by bleak when the connection is lost unexpectedly."""
+        self._connected = False
+        _LOGGER.warning("Connection lost to %s", self._address)
+        if self._pending and not self._pending.done():
+            self._pending.set_result(None)
+        if self._reconnect_task is None or self._reconnect_task.done():
+            self._reconnect_task = asyncio.ensure_future(self._reconnect())
+
+    async def _reconnect(self) -> None:
+        """Attempt to reconnect with exponential backoff."""
+        delay = _RECONNECT_DELAY_INITIAL
+        while not self._connected:
+            _LOGGER.info(
+                "Attempting reconnect to %s in %.0fs", self._address, delay
+            )
+            await asyncio.sleep(delay)
+            try:
+                await self.connect()
+                return
+            except Exception as exc:
+                _LOGGER.warning("Reconnect failed: %s", exc)
+                delay = min(delay * 2, _RECONNECT_DELAY_MAX)

--- a/custom_components/velit/const.py
+++ b/custom_components/velit/const.py
@@ -22,6 +22,17 @@ HEATER_START_BYTE = 0x55
 HEATER_RESPONSE_START = 0xAA
 HEATER_MFG_CODE = bytes([0x53, 0x46])  # "SF" — validated in every heater response
 
+# Heater packet addressing — verified on hardware (2026-03-25, Velit 4000P).
+# The slave address 0x0000002D is a fixed constant on all known Velit heaters — it is NOT
+# derived from the BLE MAC address and does not uniquely identify a device at the protocol
+# level. Device isolation is provided entirely by the BLE connection (we connect to a specific
+# BLE address); the slave address in the packet is effectively a protocol constant.
+# The master address is arbitrary — the device responds regardless of its value.
+# Cross-device contamination (reported in campsite scenarios) is a Velit app issue caused by
+# connecting to the wrong BLE device, not a protocol addressing issue.
+HEATER_MASTER_ADDR = bytes([0x00, 0x00, 0x00, 0x01])
+HEATER_SLAVE_ADDR = bytes([0x00, 0x00, 0x00, 0x2D])
+
 # AC protocol constants (V1.01)
 AC_START_BYTES = bytes([0x5A, 0x5A])
 AC_END_BYTES = bytes([0x0D, 0x0A])

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -28,7 +28,7 @@ from typing import Union
 from bleak import BleakClient, BLEDevice
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
-from .const import UUID_READ_NOTIFY, UUID_WRITE
+from .const import HEATER_MASTER_ADDR, HEATER_SLAVE_ADDR, UUID_READ_NOTIFY, UUID_WRITE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,14 +155,15 @@ class VelitHeaterClient:
     def __init__(
         self,
         address: Union[str, BLEDevice],
-        master_addr: bytes = bytes([0x00, 0x00, 0x00, 0x01]),
-        slave_addr: bytes = bytes([0x00, 0x00, 0x00, 0x01]),
+        master_addr: bytes = HEATER_MASTER_ADDR,
+        slave_addr: bytes = HEATER_SLAVE_ADDR,
     ) -> None:
         """
         Args:
             address:     BLE device address or BLEDevice from discovery.
-            master_addr: 4-byte address placed in the master field of each packet.
-            slave_addr:  4-byte address placed in the slave field of each packet.
+            master_addr: 4-byte master address (arbitrary — device ignores its value).
+            slave_addr:  4-byte slave address (fixed constant on all known Velit heaters;
+                         device isolation is provided by the BLE connection, not this field).
         """
         self._address = address
         self._master_addr = master_addr

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -1,8 +1,7 @@
-"""Heater BLE packet builder and response parser.
+"""Heater BLE packet builder, response parser, and connection client.
 
 Protocol: Velit Air Heater Communication Protocol V1.02.
-This module handles packet construction and parsing only.
-BLE connection management is implemented separately.
+Packet construction, parsing, and BLE connection management are all here.
 
 Packet structure (command, master to slave):
   [0x55][length][master 4B][slave 4B][func][data N][checksum 2B]
@@ -22,7 +21,14 @@ assigned or discovered is not yet known. Needs hardware investigation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import Union
+
+from bleak import BleakClient, BLEDevice
+from bleak.backends.characteristic import BleakGATTCharacteristic
+
+from .const import UUID_READ_NOTIFY, UUID_WRITE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,3 +129,185 @@ def _validate_response_checksum(raw: bytes) -> bool:
     """
     expected = _heater_checksum(raw[:-2])
     return raw[-2:] == expected
+
+
+# ---------------------------------------------------------------------------
+# BLE connection layer
+# ---------------------------------------------------------------------------
+
+_RECONNECT_DELAY_INITIAL = 1.0   # seconds
+_RECONNECT_DELAY_MAX = 30.0      # seconds
+_COMMAND_TIMEOUT = 5.0           # seconds to wait for a notification response
+
+
+class VelitHeaterClient:
+    """BLE client for the Velit heater protocol (V1.02).
+
+    Manages connection, command serialisation, and notification handling.
+
+    Open question: the 4-byte master/slave addresses used in the packet
+    framing are not the same as BLE MAC addresses. How they are assigned
+    or derived is not yet known — hardware investigation required.
+    The constructor accepts them explicitly so the discover tool can probe
+    different values until the device responds.
+    """
+
+    def __init__(
+        self,
+        address: Union[str, BLEDevice],
+        master_addr: bytes = bytes([0x00, 0x00, 0x00, 0x01]),
+        slave_addr: bytes = bytes([0x00, 0x00, 0x00, 0x01]),
+    ) -> None:
+        """
+        Args:
+            address:     BLE device address or BLEDevice from discovery.
+            master_addr: 4-byte address placed in the master field of each packet.
+            slave_addr:  4-byte address placed in the slave field of each packet.
+        """
+        self._address = address
+        self._master_addr = master_addr
+        self._slave_addr = slave_addr
+        self._client: BleakClient | None = None
+        self._queue: asyncio.Queue[
+            tuple[int, bytes, asyncio.Future[dict | None]]
+        ] = asyncio.Queue()
+        # Resolved by the notification handler for whichever command is in flight.
+        self._pending: asyncio.Future[dict | None] | None = None
+        self._connected = False
+        self._queue_task: asyncio.Task | None = None
+        self._reconnect_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """Connect to the device and subscribe to response notifications."""
+        self._client = BleakClient(
+            self._address,
+            disconnected_callback=self._on_disconnect,
+        )
+        await self._client.connect()
+        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._connected = True
+        self._queue_task = asyncio.ensure_future(self._queue_runner())
+        _LOGGER.info("Connected to %s", self._address)
+
+    async def disconnect(self) -> None:
+        """Disconnect cleanly, stopping the command queue first."""
+        self._connected = False
+
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+
+        if self._queue_task and not self._queue_task.done():
+            self._queue_task.cancel()
+
+        if self._client and self._client.is_connected:
+            try:
+                await self._client.stop_notify(UUID_READ_NOTIFY)
+            except Exception:
+                pass
+            await self._client.disconnect()
+
+        _LOGGER.info("Disconnected from %s", self._address)
+
+    async def send_command(
+        self, func: int, data: bytes, timeout: float = _COMMAND_TIMEOUT
+    ) -> dict | None:
+        """Queue a command and wait for the parsed response.
+
+        Returns the parsed response dict or None on timeout or connection error.
+        """
+        if not self._connected:
+            _LOGGER.debug("send_command called while not connected")
+            return None
+
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[dict | None] = loop.create_future()
+        await self._queue.put((func, data, fut))
+        try:
+            # Allow extra headroom beyond the per-command timeout so the caller
+            # future is never orphaned inside the queue.
+            return await asyncio.wait_for(fut, timeout=timeout + 2.0)
+        except asyncio.TimeoutError:
+            _LOGGER.warning("send_command timed out waiting for result (func 0x%02X)", func)
+            return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _queue_runner(self) -> None:
+        """Process commands one at a time until disconnected."""
+        while self._connected:
+            try:
+                func, data, caller_fut = await asyncio.wait_for(
+                    self._queue.get(), timeout=1.0
+                )
+            except asyncio.TimeoutError:
+                continue
+
+            loop = asyncio.get_running_loop()
+            self._pending = loop.create_future()
+            result: dict | None = None
+
+            try:
+                packet = build_command(
+                    self._master_addr, self._slave_addr, func, data
+                )
+                await self._client.write_gatt_char(  # type: ignore[union-attr]
+                    UUID_WRITE, packet, response=True
+                )
+                try:
+                    result = await asyncio.wait_for(
+                        asyncio.shield(self._pending), timeout=_COMMAND_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    _LOGGER.warning(
+                        "No notification within %.0fs for func 0x%02X",
+                        _COMMAND_TIMEOUT, func,
+                    )
+            except Exception as exc:
+                _LOGGER.warning("Command write failed (func 0x%02X): %s", func, exc)
+            finally:
+                self._pending = None
+                self._queue.task_done()
+
+            if not caller_fut.done():
+                caller_fut.set_result(result)
+
+    def _on_notification(
+        self, _char: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle an incoming notification from the device."""
+        parsed = parse_response(bytes(data))
+        if self._pending and not self._pending.done():
+            self._pending.set_result(parsed)
+        elif parsed:
+            _LOGGER.debug("Unsolicited notification: func 0x%02X", parsed.get("func"))
+
+    def _on_disconnect(self, _client: BleakClient) -> None:
+        """Called by bleak when the connection is lost unexpectedly."""
+        self._connected = False
+        _LOGGER.warning("Connection lost to %s", self._address)
+        # Cancel any in-flight command future so the caller does not hang.
+        if self._pending and not self._pending.done():
+            self._pending.set_result(None)
+        if self._reconnect_task is None or self._reconnect_task.done():
+            self._reconnect_task = asyncio.ensure_future(self._reconnect())
+
+    async def _reconnect(self) -> None:
+        """Attempt to reconnect with exponential backoff."""
+        delay = _RECONNECT_DELAY_INITIAL
+        while not self._connected:
+            _LOGGER.info(
+                "Attempting reconnect to %s in %.0fs", self._address, delay
+            )
+            await asyncio.sleep(delay)
+            try:
+                await self.connect()
+                return
+            except Exception as exc:
+                _LOGGER.warning("Reconnect failed: %s", exc)
+                delay = min(delay * 2, _RECONNECT_DELAY_MAX)

--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -10,8 +10,8 @@
   "requirements": [],
   "version": "0.0.1",
   "bluetooth": [
-    {"local_name": "VELIT", "connectable": true},
-    {"local_name": "VLIT", "connectable": true},
-    {"local_name": "D30", "connectable": true}
+    {"local_name": "VELIT*", "connectable": true},
+    {"local_name": "VLIT*", "connectable": true},
+    {"local_name": "D30*", "connectable": true}
   ]
 }


### PR DESCRIPTION
## Summary

- `VelitHeaterClient`: BLE connect/disconnect lifecycle, write to FFe2, subscribe notifications on FFe1, asyncio.Queue command serialisation, exponential backoff reconnect (1s to 30s cap)
- `VelitACClient`: same connection and queue pattern, enforces 400ms minimum inter-command delay, retries once on timeout, marks unavailable after 3 consecutive failures
- Slave address 0x0000002D confirmed as fixed constant on all known Velit heaters (verified on hardware 2026-03-25) — master address is arbitrary
- connect() disconnects before re-raising on failed start_notify() to prevent stale BlueZ state
- _on_disconnect() returns early when _connected is False to prevent spurious reconnect loops on failed connect attempts

**Merge after:** feature/packet-layer
**Merge before:** feature/config-flow