### PR TITLE
Phase 3: config flow with Bluetooth discovery and manual entry

### DIFF
--- a/custom_components/velit/ac_client.py
+++ b/custom_components/velit/ac_client.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Union
 
 from bleak import BleakClient, BLEDevice
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -151,7 +150,7 @@ class VelitACClient:
 
     def __init__(
         self,
-        address: Union[str, BLEDevice],
+        address: str | BLEDevice,
         product_code: int = DEFAULT_PRODUCT_CODE,
     ) -> None:
         """
@@ -188,7 +187,7 @@ class VelitACClient:
         self._connected = True
         self.unavailable = False
         self._consecutive_failures = 0
-        self._queue_task = asyncio.ensure_future(self._queue_runner())
+        self._queue_task = asyncio.create_task(self._queue_runner())
         _LOGGER.info("Connected to %s", self._address)
 
     async def disconnect(self) -> None:
@@ -348,7 +347,7 @@ class VelitACClient:
         if self._pending and not self._pending.done():
             self._pending.set_result(None)
         if self._reconnect_task is None or self._reconnect_task.done():
-            self._reconnect_task = asyncio.ensure_future(self._reconnect())
+            self._reconnect_task = asyncio.create_task(self._reconnect())
 
     async def _reconnect(self) -> None:
         """Attempt to reconnect with exponential backoff."""

--- a/custom_components/velit/config_flow.py
+++ b/custom_components/velit/config_flow.py
@@ -84,8 +84,6 @@ class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle manual entry — user provides the BLE device address."""
-        errors: dict[str, str] = {}
-
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
             await self.async_set_unique_id(address)
@@ -97,7 +95,6 @@ class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({vol.Required(CONF_ADDRESS): str}),
-            errors=errors,
         )
 
     # ------------------------------------------------------------------

--- a/custom_components/velit/config_flow.py
+++ b/custom_components/velit/config_flow.py
@@ -1,0 +1,144 @@
+"""Config flow for the Velit integration.
+
+Two entry paths:
+  - Bluetooth discovery: HA detects a Velit advertisement and calls
+    async_step_bluetooth automatically.
+  - Manual: user initiates from the UI and enters the BLE address.
+
+Both paths converge at async_step_device_type where the user selects
+Heater or AC and assigns a friendly name. Device type cannot be inferred
+from the BLE advertisement — user selection is the safe fallback until
+hardware verification confirms a reliable automatic detection method.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    TextSelector,
+)
+
+from .const import DEVICE_TYPE_AC, DEVICE_TYPE_HEATER, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle the Velit config flow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        self._address: str = ""
+        self._name: str = ""
+
+    # ------------------------------------------------------------------
+    # Bluetooth discovery path
+    # ------------------------------------------------------------------
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> ConfigFlowResult:
+        """Handle a device discovered via Bluetooth.
+
+        Called automatically by HA when an advertisement matches a
+        manifest bluetooth matcher. Sets unique ID from the BLE address
+        and aborts if this device is already configured.
+        """
+        await self.async_set_unique_id(discovery_info.address)
+        self._abort_if_unique_id_configured()
+
+        self._address = discovery_info.address
+        self._name = discovery_info.name or discovery_info.address
+        self.context["title_placeholders"] = {"name": self._name}
+
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show a confirmation form before proceeding to device type selection."""
+        if user_input is not None:
+            return await self.async_step_device_type()
+
+        return self.async_show_form(
+            step_id="bluetooth_confirm",
+            description_placeholders={"name": self._name},
+        )
+
+    # ------------------------------------------------------------------
+    # Manual entry path
+    # ------------------------------------------------------------------
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle manual entry — user provides the BLE device address."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            await self.async_set_unique_id(address)
+            self._abort_if_unique_id_configured()
+            self._address = address
+            self._name = address
+            return await self.async_step_device_type()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_ADDRESS): str}),
+            errors=errors,
+        )
+
+    # ------------------------------------------------------------------
+    # Shared step — device type and name
+    # ------------------------------------------------------------------
+
+    async def async_step_device_type(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select device type (Heater / AC) and assign a friendly name.
+
+        Device type cannot be reliably inferred from the BLE advertisement
+        at this time — user selection is required.
+        """
+        if user_input is not None:
+            return self.async_create_entry(
+                title=user_input[CONF_NAME],
+                data={
+                    CONF_ADDRESS: self._address,
+                    "device_type": user_input["device_type"],
+                    CONF_NAME: user_input[CONF_NAME],
+                },
+            )
+
+        return self.async_show_form(
+            step_id="device_type",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("device_type"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                SelectOptionDict(
+                                    value=DEVICE_TYPE_HEATER, label="Heater"
+                                ),
+                                SelectOptionDict(
+                                    value=DEVICE_TYPE_AC, label="Air Conditioner"
+                                ),
+                            ]
+                        )
+                    ),
+                    vol.Required(CONF_NAME, default=self._name): TextSelector(),
+                }
+            ),
+        )

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -14,16 +14,16 @@ high byte first. Verified against 11 of 12 protocol examples — the shutdown
 command example (func 0x02) appears to contain a typo in the source document
 and does not match the formula. Hardware verification required.
 
-Open question: the 4-byte master/slave addresses used in the protocol are not
-the same as BLE MAC addresses (which are 6 bytes). How these addresses are
-assigned or discovered is not yet known. Needs hardware investigation.
+Addressing: slave address 0x0000002D is a fixed constant on all known Velit
+heaters — verified on hardware (2026-03-25). Master address is arbitrary.
+Device isolation is provided by the BLE connection, not protocol addressing.
+See HEATER_MASTER_ADDR / HEATER_SLAVE_ADDR in const.py.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Union
 
 from bleak import BleakClient, BLEDevice
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -145,16 +145,14 @@ class VelitHeaterClient:
 
     Manages connection, command serialisation, and notification handling.
 
-    Open question: the 4-byte master/slave addresses used in the packet
-    framing are not the same as BLE MAC addresses. How they are assigned
-    or derived is not yet known — hardware investigation required.
-    The constructor accepts them explicitly so the discover tool can probe
-    different values until the device responds.
+    Slave address 0x0000002D is a fixed constant on all known Velit heaters
+    (verified on hardware, 2026-03-25). Master address is arbitrary. Both
+    default to the confirmed values from const.py.
     """
 
     def __init__(
         self,
-        address: Union[str, BLEDevice],
+        address: str | BLEDevice,
         master_addr: bytes = HEATER_MASTER_ADDR,
         slave_addr: bytes = HEATER_SLAVE_ADDR,
     ) -> None:
@@ -191,7 +189,7 @@ class VelitHeaterClient:
         await self._client.connect()
         await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
         self._connected = True
-        self._queue_task = asyncio.ensure_future(self._queue_runner())
+        self._queue_task = asyncio.create_task(self._queue_runner())
         _LOGGER.info("Connected to %s", self._address)
 
     async def disconnect(self) -> None:
@@ -296,7 +294,7 @@ class VelitHeaterClient:
         if self._pending and not self._pending.done():
             self._pending.set_result(None)
         if self._reconnect_task is None or self._reconnect_task.done():
-            self._reconnect_task = asyncio.ensure_future(self._reconnect())
+            self._reconnect_task = asyncio.create_task(self._reconnect())
 
     async def _reconnect(self) -> None:
         """Attempt to reconnect with exponential backoff."""

--- a/custom_components/velit/packet_utils.py
+++ b/custom_components/velit/packet_utils.py
@@ -1,10 +1,18 @@
 """Shared packet utilities for Velit heater and AC protocols.
 
 Temperature handling strategy:
-  The integration always operates devices in Celsius mode. On connect, the
-  coordinator sends one Celsius temperature command to switch the device out
-  of its default Fahrenheit mode. All subsequent sensor readings and set
-  commands use Celsius. HA handles display conversion for users who prefer °F.
+  The integration preserves whatever temperature unit is currently active on
+  the device, to avoid changing what is shown on the physical LCD display.
+
+  On connect the coordinator sends Query 1 (func 0x0A) and infers the active
+  unit from the Set Temperature field in the response:
+    - Value 16–30  → device is in Celsius mode
+    - Value 61–86  → device is in Fahrenheit mode
+    - Anything else → fall back to hass.config.units.temperature_unit
+
+  All subsequent SET commands and sensor decodings use that unit. The
+  coordinator converts to Celsius before reporting to HA so that HA can
+  apply display conversion for users who prefer the other unit.
 
 Two distinct temperature encodings exist in the protocol:
 

--- a/custom_components/velit/packet_utils.py
+++ b/custom_components/velit/packet_utils.py
@@ -1,4 +1,23 @@
-"""Shared packet utilities for Velit heater and AC protocols."""
+"""Shared packet utilities for Velit heater and AC protocols.
+
+Temperature handling strategy:
+  The integration always operates devices in Celsius mode. On connect, the
+  coordinator sends one Celsius temperature command to switch the device out
+  of its default Fahrenheit mode. All subsequent sensor readings and set
+  commands use Celsius. HA handles display conversion for users who prefer °F.
+
+Two distinct temperature encodings exist in the protocol:
+
+  SET commands (func 0x08):
+    The data byte is the raw integer temperature value — no offset.
+    celsius_to_hex / fahrenheit_to_hex are identity functions by design.
+
+  QUERY responses (Query 2, func 0x0B):
+    Sensor readings use an offset encoding verified on hardware:
+      Celsius mode:    raw - 50 = °C   (range 0–250 maps to -50°C–200°C)
+      Fahrenheit mode: raw - 60 = °F   (range 0–700 maps to -60°F–640°F)
+    hex_to_celsius / hex_to_fahrenheit apply these offsets.
+"""
 
 from __future__ import annotations
 
@@ -11,27 +30,39 @@ from .const import (
 
 
 def celsius_to_hex(temp_c: int) -> int:
-    """Return the hex value transmitted for a Celsius temperature.
+    """Return the byte value to transmit for a Celsius SET command.
 
-    Both devices transmit the raw integer degree value as a single hex byte.
-    Formula: F = 1.8 * C + 32 (used when transmitting Fahrenheit instead).
+    The protocol transmits the raw integer degree value — no offset applied.
     """
     return temp_c
 
 
 def fahrenheit_to_hex(temp_f: int) -> int:
-    """Return the hex value transmitted for a Fahrenheit temperature."""
+    """Return the byte value to transmit for a Fahrenheit SET command.
+
+    The protocol transmits the raw integer degree value — no offset applied.
+    Retained for completeness; the integration operates in Celsius mode.
+    """
     return temp_f
 
 
 def hex_to_celsius(value: int) -> int:
-    """Convert a received hex temperature value to Celsius."""
-    return value
+    """Decode a raw sensor temperature value (from Query 2) to Celsius.
+
+    Applies the protocol offset: raw - 50 = °C.
+    Verified on hardware: device in Celsius mode.
+    """
+    return value - 50
 
 
 def hex_to_fahrenheit(value: int) -> int:
-    """Convert a received hex temperature value to Fahrenheit."""
-    return value
+    """Decode a raw sensor temperature value (from Query 2) to Fahrenheit.
+
+    Applies the protocol offset: raw - 60 = °F.
+    Verified on hardware (2026-03-25): inlet 0x0083=131, 131-60=71°F confirmed.
+    Retained for completeness; the integration operates in Celsius mode.
+    """
+    return value - 60
 
 
 def celsius_to_fahrenheit(temp_c: float) -> float:
@@ -52,7 +83,8 @@ def is_valid_heater_temp_c(temp_c: int) -> bool:
 def is_valid_heater_temp_f(temp_f: int) -> bool:
     """Return True if the temperature is within the heater's Fahrenheit range.
 
-    F range per protocol: 61–86°F (hex 0x3D–0x56).
+    F range: 61–86°F (16–30°C converted). Hex: 0x3D–0x56.
+    Retained for completeness; the integration operates in Celsius mode.
     """
     return 61 <= temp_f <= 86
 
@@ -65,6 +97,7 @@ def is_valid_ac_temp_c(temp_c: int) -> bool:
 def is_valid_ac_temp_f(temp_f: int) -> bool:
     """Return True if the temperature is within the AC's Fahrenheit range.
 
-    F range per protocol: 61–86°F (hex 0x3D–0x56).
+    F range: 63–86°F (17–30°C converted: 17°C = 62.6°F → 63°F minimum).
+    Retained for completeness; the integration operates in Celsius mode.
     """
-    return 61 <= temp_f <= 86
+    return 63 <= temp_f <= 86

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -14,10 +14,11 @@
         "description": "Set up {name}?"
       },
       "device_type": {
-        "title": "Select Device Type",
-        "description": "Is this device a heater or an air conditioner?",
+        "title": "Configure Device",
+        "description": "Select the device type and give it a name to identify it in Home Assistant.",
         "data": {
-          "device_type": "Device Type"
+          "device_type": "Device Type",
+          "name": "Device Name"
         }
       }
     },

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -14,10 +14,11 @@
         "description": "Set up {name}?"
       },
       "device_type": {
-        "title": "Select Device Type",
-        "description": "Is this device a heater or an air conditioner?",
+        "title": "Configure Device",
+        "description": "Select the device type and give it a name to identify it in Home Assistant.",
         "data": {
-          "device_type": "Device Type"
+          "device_type": "Device Type",
+          "name": "Device Name"
         }
       }
     },

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,7 @@ pytest>=7.0
 pytest-cov
 syrupy
 ruff
+# Transitive dependencies pulled in by HA's bluetooth/USB components at import time.
+# Not declared by pytest-homeassistant-custom-component but required for tests to collect.
+aiousbwatcher
+pyserial

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,11 @@
-# Shared test fixtures for the Velit integration test suite.
-# Populated as platforms and coordinators are implemented in later phases.
+# Shared fixtures for the Velit integration test suite.
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations: None) -> None:
+    """Enable custom integration loading for all tests in this suite."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,212 @@
+"""Tests for the Velit config flow.
+
+Covers both the Bluetooth discovery path and the manual user path,
+including unique ID deduplication and two-device scenarios.
+
+No hardware required — HA test helpers provide mock BLE discovery objects.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.velit.const import DEVICE_TYPE_AC, DEVICE_TYPE_HEATER, DOMAIN
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+HEATER_ADDRESS = "AA:BB:CC:DD:EE:01"
+HEATER_NAME = "VELIT-VB52_FHJ/4/1"
+
+AC_ADDRESS = "AA:BB:CC:DD:EE:02"
+AC_NAME = "VELIT-AC01_XYZ/1/1"
+
+
+def _make_discovery(address: str, name: str) -> BluetoothServiceInfoBleak:
+    """Return a minimal BluetoothServiceInfoBleak for testing."""
+    return BluetoothServiceInfoBleak(
+        name=name,
+        address=address,
+        rssi=-60,
+        manufacturer_data={},
+        service_data={},
+        service_uuids=[],
+        source="local",
+        device=None,  # type: ignore[arg-type]
+        advertisement=None,  # type: ignore[arg-type]
+        connectable=True,
+        time=0.0,
+        tx_power=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bluetooth discovery path
+# ---------------------------------------------------------------------------
+
+
+async def test_bluetooth_discovery_full_flow(hass: HomeAssistant) -> None:
+    """Discovery → confirm → device type + name → entry created."""
+    discovery = _make_discovery(HEATER_ADDRESS, HEATER_NAME)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=discovery,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "device_type"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"device_type": DEVICE_TYPE_HEATER, CONF_NAME: "Cab Heater"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Cab Heater"
+    assert result["data"] == {
+        CONF_ADDRESS: HEATER_ADDRESS,
+        "device_type": DEVICE_TYPE_HEATER,
+        CONF_NAME: "Cab Heater",
+    }
+
+
+async def test_bluetooth_discovery_ac(hass: HomeAssistant) -> None:
+    """Discovery flow correctly stores AC device type."""
+    discovery = _make_discovery(AC_ADDRESS, AC_NAME)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=discovery,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"device_type": DEVICE_TYPE_AC, CONF_NAME: "Bedroom AC"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"]["device_type"] == DEVICE_TYPE_AC
+
+
+async def test_bluetooth_discovery_duplicate_aborts(hass: HomeAssistant) -> None:
+    """A second discovery for the same address aborts as already_configured."""
+    discovery = _make_discovery(HEATER_ADDRESS, HEATER_NAME)
+
+    # First flow — complete it
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=discovery,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"device_type": DEVICE_TYPE_HEATER, CONF_NAME: "Heater"},
+    )
+
+    # Second flow — same address should abort
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=discovery,
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_bluetooth_two_different_devices(hass: HomeAssistant) -> None:
+    """Two different BLE addresses each produce a separate config entry."""
+    for address, name, device_type, label in [
+        (HEATER_ADDRESS, HEATER_NAME, DEVICE_TYPE_HEATER, "Heater"),
+        (AC_ADDRESS, AC_NAME, DEVICE_TYPE_AC, "AC"),
+    ]:
+        discovery = _make_discovery(address, name)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_BLUETOOTH},
+            data=discovery,
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"device_type": device_type, CONF_NAME: label},
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 2
+    addresses = {e.data[CONF_ADDRESS] for e in entries}
+    assert addresses == {HEATER_ADDRESS, AC_ADDRESS}
+
+
+# ---------------------------------------------------------------------------
+# Manual user path
+# ---------------------------------------------------------------------------
+
+
+async def test_user_flow_full(hass: HomeAssistant) -> None:
+    """Manual entry → device type + name → entry created."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_ADDRESS: HEATER_ADDRESS}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "device_type"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"device_type": DEVICE_TYPE_HEATER, CONF_NAME: "Van Heater"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_ADDRESS] == HEATER_ADDRESS
+    assert result["data"]["device_type"] == DEVICE_TYPE_HEATER
+
+
+async def test_user_flow_duplicate_aborts(hass: HomeAssistant) -> None:
+    """Manual entry with an already-configured address aborts."""
+    # Create an existing entry
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_ADDRESS: HEATER_ADDRESS}
+    )
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"device_type": DEVICE_TYPE_HEATER, CONF_NAME: "Heater"},
+    )
+
+    # Second attempt with the same address
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_ADDRESS: HEATER_ADDRESS}
+    )
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -20,7 +20,10 @@ from custom_components.velit.heater_client import parse_response as heater_parse
 from custom_components.velit.packet_utils import (
     celsius_to_fahrenheit,
     fahrenheit_to_celsius,
+    hex_to_celsius,
+    hex_to_fahrenheit,
     is_valid_ac_temp_c,
+    is_valid_ac_temp_f,
     is_valid_heater_temp_c,
     is_valid_heater_temp_f,
 )
@@ -311,8 +314,27 @@ class TestTemperatureUtils:
         assert is_valid_heater_temp_f(60) is False
         assert is_valid_heater_temp_f(87) is False
 
+    def test_hex_to_fahrenheit(self):
+        # Offset encoding verified on hardware (2026-03-25): raw - 60 = °F.
+        # Inlet sensor returned 0x0083=131; 131-60=71°F confirmed.
+        assert hex_to_fahrenheit(131) == 71
+        assert hex_to_fahrenheit(60) == 0    # lower bound of protocol range
+
+    def test_hex_to_celsius(self):
+        # Offset encoding per protocol doc: raw - 50 = °C.
+        assert hex_to_celsius(50) == 0       # 0°C
+        assert hex_to_celsius(71) == 21      # 21°C (≈ 71°F, expected room temp)
+        assert hex_to_celsius(250) == 200    # upper bound of protocol range
+
     def test_ac_valid_celsius_range(self):
         assert is_valid_ac_temp_c(17) is True
         assert is_valid_ac_temp_c(30) is True
         assert is_valid_ac_temp_c(16) is False
         assert is_valid_ac_temp_c(31) is False
+
+    def test_ac_valid_fahrenheit_range(self):
+        # AC minimum is 17°C = 62.6°F → 63°F integer minimum.
+        assert is_valid_ac_temp_f(63) is True
+        assert is_valid_ac_temp_f(86) is True
+        assert is_valid_ac_temp_f(62) is False
+        assert is_valid_ac_temp_f(87) is False


### PR DESCRIPTION
## Summary

- `VelitConfigFlow`: Bluetooth discovery path (async_step_bluetooth) and manual fallback (async_step_user), shared device type + name step
- async_set_unique_id + _abort_if_unique_id_configured prevents duplicate entries; second device with different address creates independently
- BT local_name matchers use fnmatch glob: VELIT*, VLIT*, D30* in manifest.json
- HEATER_MASTER_ADDR / HEATER_SLAVE_ADDR constants with cross-van contamination explanation
- pytest.ini (asyncio_mode=auto), conftest.py (enable_custom_integrations fixture)
- tests/test_config_flow.py: 6 tests covering both paths, dedup, two-device scenario

**Merge after:** feature/ble-connection
**Merge before:** feature/coordinator-entities