### PR TITLE
Phase 4: coordinator, climate entities, and sensor entities

### DIFF
--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -38,6 +38,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"Could not connect to Velit device at {entry.data['address']}: {exc}"
         ) from exc
 
+    # Register disconnect before first refresh so it runs even if refresh fails.
+    entry.async_on_unload(coordinator.async_disconnect)
+
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
@@ -48,11 +51,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a Velit config entry."""
-    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    """Unload a Velit config entry.
 
-    if unloaded:
-        coordinator = entry.runtime_data
-        await coordinator.async_disconnect()
-
-    return unloaded
+    Disconnect is handled automatically by the callback registered in
+    async_setup_entry via entry.async_on_unload — no manual cleanup needed here.
+    """
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -14,7 +14,7 @@ from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.CLIMATE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -5,20 +5,54 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DEVICE_TYPE_HEATER
+from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Populated in later phases as platforms are implemented.
-PLATFORMS: list[str] = []
+PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up a Velit device from a config entry."""
-    # Full implementation added in coordinator and entity phases.
+    """Set up a Velit device from a config entry.
+
+    Creates the appropriate coordinator, connects to the device, runs the
+    first data refresh, and forwards setup to all platforms.
+
+    Raises ConfigEntryNotReady if the device cannot be reached on startup —
+    HA will retry automatically with backoff.
+    """
+    if entry.data["device_type"] == DEVICE_TYPE_HEATER:
+        coordinator = VelitHeaterCoordinator(hass, entry)
+    else:
+        coordinator = VelitACCoordinator(hass, entry)
+
+    try:
+        await coordinator.async_connect()
+    except Exception as exc:
+        raise ConfigEntryNotReady(
+            f"Could not connect to Velit device at {entry.data['address']}: {exc}"
+        ) from exc
+
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a Velit config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unloaded:
+        coordinator = entry.runtime_data
+        await coordinator.async_disconnect()
+
+    return unloaded

--- a/custom_components/velit/ac_client.py
+++ b/custom_components/velit/ac_client.py
@@ -178,12 +178,23 @@ class VelitACClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        self._client = BleakClient(
+        client = BleakClient(
             self._address,
             disconnected_callback=self._on_disconnect,
         )
-        await self._client.connect()
-        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._client = client
+        try:
+            await client.connect()
+            await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        except Exception:
+            # Disconnect before re-raising so BlueZ releases this connection and
+            # any stale notification subscription — prevents "Notify acquired" on
+            # the next attempt.
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+            raise
         self._connected = True
         self.unavailable = False
         self._consecutive_failures = 0
@@ -342,6 +353,11 @@ class VelitACClient:
 
     def _on_disconnect(self, _client: BleakClient) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
+        if not self._connected:
+            # The disconnect fired during a failed connect() attempt —
+            # _connected was never set True. connect() handles its own cleanup;
+            # do not start a reconnect loop here.
+            return
         self._connected = False
         _LOGGER.warning("Connection lost to %s", self._address)
         if self._pending and not self._pending.done():

--- a/custom_components/velit/button.py
+++ b/custom_components/velit/button.py
@@ -1,0 +1,135 @@
+"""Button entities for Velit heater devices.
+
+Exposes one-shot and toggled maintenance commands as HA button entities.
+These are diagnostic/advanced controls not needed for normal operation.
+
+Buttons:
+  VelitHeaterPrimeFuelPumpButton  — starts fuel pump (0x05), auto-stops after
+      30 seconds (0x06). Pressing again while priming stops it immediately,
+      mirroring the single-button behaviour on the physical hardware interface.
+  VelitHeaterCleaningButton       — triggers residual fuel clearance (0x09),
+      a one-shot command with no stop counterpart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DEVICE_TYPE_HEATER, DOMAIN
+from .coordinator import VelitHeaterCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Duration in seconds before the prime sequence auto-stops, matching the
+# default behaviour of the physical hardware button.
+_PRIME_AUTO_STOP_SECONDS = 30
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Velit button entities from a config entry."""
+    if entry.data["device_type"] != DEVICE_TYPE_HEATER:
+        return
+
+    coordinator: VelitHeaterCoordinator = entry.runtime_data
+    async_add_entities([
+        VelitHeaterPrimeFuelPumpButton(coordinator, entry),
+        VelitHeaterCleaningButton(coordinator, entry),
+    ])
+
+
+class VelitHeaterPrimeFuelPumpButton(
+    CoordinatorEntity[VelitHeaterCoordinator], ButtonEntity
+):
+    """Prime the fuel pump.
+
+    First press sends func 0x05 (start pump) and schedules an automatic stop
+    (func 0x06) after 30 seconds. Pressing again while priming cancels the
+    scheduled stop and sends 0x06 immediately, matching the physical interface.
+    """
+
+    _attr_name = "Prime Fuel Pump"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:fuel"
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_prime_fuel_pump"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+        self._prime_task: asyncio.Task | None = None
+
+    async def async_press(self) -> None:
+        """Handle button press — start or stop priming."""
+        if self._prime_task and not self._prime_task.done():
+            # Already priming — cancel the scheduled stop and stop immediately.
+            self._prime_task.cancel()
+            self._prime_task = None
+            await self.coordinator._client.send_command(0x06, bytes([0x00]))
+            _LOGGER.debug("Fuel pump prime stopped early by user")
+            return
+
+        # Start priming and schedule auto-stop.
+        await self.coordinator._client.send_command(0x05, bytes([0x00]))
+        _LOGGER.debug(
+            "Fuel pump prime started; auto-stop in %ds", _PRIME_AUTO_STOP_SECONDS
+        )
+        self._prime_task = asyncio.create_task(self._auto_stop())
+
+    async def _auto_stop(self) -> None:
+        """Wait then send stop command; cancelled if user presses early."""
+        await asyncio.sleep(_PRIME_AUTO_STOP_SECONDS)
+        await self.coordinator._client.send_command(0x06, bytes([0x00]))
+        self._prime_task = None
+        _LOGGER.debug("Fuel pump prime auto-stopped after %ds", _PRIME_AUTO_STOP_SECONDS)
+
+
+class VelitHeaterCleaningButton(
+    CoordinatorEntity[VelitHeaterCoordinator], ButtonEntity
+):
+    """Trigger residual fuel clearance (cleaning mode).
+
+    Sends func 0x09 — a one-shot command that purges residual fuel from the
+    system. No stop command is required; the device manages the sequence.
+    """
+
+    _attr_name = "Clean (Residual Fuel Clearance)"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:broom"
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_cleaning"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+
+    async def async_press(self) -> None:
+        """Send the residual fuel clearance command."""
+        await self.coordinator._client.send_command(0x09, bytes([0x00]))
+        _LOGGER.debug("Residual fuel clearance command sent")

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -1,0 +1,379 @@
+"""Climate entities for Velit heater and AC devices.
+
+One entity class per device type — the protocols and capability sets are
+different enough that a shared class would obscure more than it unifies.
+
+Both entities read state exclusively from their coordinator's data dict and
+never issue queries themselves. Actions send a command via the coordinator's
+client then trigger an immediate coordinator refresh so state reflects the
+confirmed device response without waiting for the next poll cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DEVICE_TYPE_HEATER,
+    DOMAIN,
+    HEATER_MAX_TEMP_C,
+    HEATER_MIN_TEMP_C,
+    AC_MAX_TEMP_C,
+    AC_MIN_TEMP_C,
+)
+from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
+from .packet_utils import celsius_to_fahrenheit
+
+_LOGGER = logging.getLogger(__name__)
+
+# Heater work mode codes (Query 1 response, work_mode field).
+_HEATER_MODE_MANUAL = 1
+_HEATER_MODE_THERMOSTAT = 2
+
+# AC operation mode codes (func 0x02).
+_AC_MODE_COOL = 1
+_AC_MODE_HEAT = 2
+_AC_MODE_FAN = 3
+_AC_MODE_ENERGY_SAVING = 4
+_AC_MODE_SLEEP = 5
+_AC_MODE_TURBO = 6
+_AC_MODE_DEHUMIDIFY = 7
+_AC_MODE_VENT = 8
+
+# Preset names used in HA for AC modes that don't map directly to HVACMode.
+AC_PRESET_NONE = "none"
+AC_PRESET_ENERGY_SAVING = "energy_saving"
+AC_PRESET_SLEEP = "sleep"
+AC_PRESET_TURBO = "turbo"
+
+# Fan modes exposed to HA — string labels matching gear/speed numbers.
+FAN_MODES = ["1", "2", "3", "4", "5"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Velit climate entity from a config entry."""
+    coordinator = entry.runtime_data
+
+    if entry.data["device_type"] == DEVICE_TYPE_HEATER:
+        async_add_entities([VelitHeaterClimateEntity(coordinator, entry)])
+    else:
+        async_add_entities([VelitACClimateEntity(coordinator, entry)])
+
+
+class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], ClimateEntity):
+    """Climate entity for a Velit heater (protocol V1.02).
+
+    HVAC modes:
+      OFF       — heater is shut down
+      HEAT      — heater running (manual or thermostat preset)
+      FAN_ONLY  — ventilation only (func 0x03 / 0x04)
+
+    Presets (only meaningful in HEAT mode):
+      manual      — fixed gear, no thermostat
+      thermostat  — thermostat controls output
+
+    Fan modes: gear levels 1–5 (only meaningful in manual mode).
+    """
+
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.FAN_ONLY]
+    _attr_preset_modes = ["manual", "thermostat"]
+    _attr_fan_modes = FAN_MODES
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 1.0
+    _attr_min_temp = float(HEATER_MIN_TEMP_C)
+    _attr_max_temp = float(HEATER_MAX_TEMP_C)
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.FAN_MODE
+    )
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.data['address']}_climate"
+        self._attr_name = entry.data.get(CONF_NAME, entry.data["address"])
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+
+    # ------------------------------------------------------------------
+    # State properties — read from coordinator data, never from device
+    # ------------------------------------------------------------------
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        if self.coordinator.data is None:
+            return None
+        state = self.coordinator.data["machine_state"]
+        if state == 0:
+            return HVACMode.OFF
+        work_mode = self.coordinator.data["work_mode"]
+        # Gear 0 with no work mode implies ventilation only.
+        if work_mode == 0:
+            return HVACMode.FAN_ONLY
+        return HVACMode.HEAT
+
+    @property
+    def preset_mode(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        work_mode = self.coordinator.data["work_mode"]
+        if work_mode == _HEATER_MODE_THERMOSTAT:
+            return "thermostat"
+        return "manual"
+
+    @property
+    def current_temperature(self) -> float | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("inlet_temp_c")
+
+    @property
+    def target_temperature(self) -> float | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("set_temp_c")
+
+    @property
+    def fan_mode(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        return str(self.coordinator.data["current_gear"])
+
+    # ------------------------------------------------------------------
+    # Actions — send command then refresh to confirm state
+    # ------------------------------------------------------------------
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        if hvac_mode == HVACMode.OFF:
+            await self.coordinator._client.send_command(0x02, bytes([0x00]))
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            await self.coordinator._client.send_command(0x03, bytes([0x00]))
+        elif hvac_mode == HVACMode.HEAT:
+            # Start in the currently selected preset mode.
+            mode_byte = (
+                0x02
+                if self.preset_mode == "thermostat"
+                else 0x01
+            )
+            await self.coordinator._client.send_command(0x01, bytes([mode_byte]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        mode_byte = 0x02 if preset_mode == "thermostat" else 0x01
+        await self.coordinator._client.send_command(0x00, bytes([mode_byte]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        temp_c = kwargs.get("temperature")
+        if temp_c is None:
+            return
+        # Send in the device's active unit to avoid flipping the LCD display unit.
+        if self.coordinator.temp_unit == UnitOfTemperature.FAHRENHEIT:
+            value = round(celsius_to_fahrenheit(temp_c))
+        else:
+            value = round(temp_c)
+        await self.coordinator._client.send_command(0x08, bytes([value]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        gear = int(fan_mode)
+        await self.coordinator._client.send_command(0x07, bytes([gear]))
+        await self.coordinator.async_request_refresh()
+
+
+class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity):
+    """Climate entity for a Velit AC unit (protocol V1.01).
+
+    HVAC modes:
+      OFF       — power off (func 0x01, data 0x01)
+      COOL      — cooling mode
+      HEAT      — heating mode
+      FAN_ONLY  — fan mode and vent mode both map here (protocols 0x03 and 0x08)
+      DRY       — dehumidify mode
+
+    Presets (active within the current HVAC mode):
+      none           — standard operation
+      energy_saving  — protocol mode 0x04
+      sleep          — protocol mode 0x05
+      turbo          — protocol mode 0x06
+
+    Note: Fan (0x03) and Vent (0x08) are both mapped to FAN_ONLY — the
+    functional difference between them is unconfirmed without hardware testing.
+    """
+
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.DRY]
+    _attr_preset_modes = [AC_PRESET_NONE, AC_PRESET_ENERGY_SAVING, AC_PRESET_SLEEP, AC_PRESET_TURBO]
+    _attr_fan_modes = FAN_MODES
+    _attr_swing_modes = ["off", "on"]
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 1.0
+    _attr_min_temp = float(AC_MIN_TEMP_C)
+    _attr_max_temp = float(AC_MAX_TEMP_C)
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.SWING_MODE
+    )
+
+    # Map from AC protocol mode codes to HA HVACMode.
+    _MODE_TO_HVAC: dict[int, HVACMode] = {
+        _AC_MODE_COOL: HVACMode.COOL,
+        _AC_MODE_HEAT: HVACMode.HEAT,
+        _AC_MODE_FAN: HVACMode.FAN_ONLY,
+        _AC_MODE_VENT: HVACMode.FAN_ONLY,   # unconfirmed; see class docstring
+        _AC_MODE_DEHUMIDIFY: HVACMode.DRY,
+    }
+
+    # Preset mode codes — these modify the current HVAC mode rather than replacing it.
+    _PRESET_CODES: dict[int, str] = {
+        _AC_MODE_ENERGY_SAVING: AC_PRESET_ENERGY_SAVING,
+        _AC_MODE_SLEEP: AC_PRESET_SLEEP,
+        _AC_MODE_TURBO: AC_PRESET_TURBO,
+    }
+
+    def __init__(
+        self,
+        coordinator: VelitACCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.data['address']}_climate"
+        self._attr_name = entry.data.get(CONF_NAME, entry.data["address"])
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+        # Tracks the last non-preset HVAC mode so we can restore it when
+        # clearing a preset (protocol requires resending the base mode code).
+        self._last_hvac_mode: HVACMode = HVACMode.COOL
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        if self.coordinator.data is None:
+            return None
+        mode_code = self.coordinator.data["mode"]
+        if mode_code == 0:
+            return HVACMode.OFF
+        # Preset codes (4, 5, 6) don't map to an HVACMode directly — return
+        # the last known base mode so the UI doesn't flip to an unexpected state.
+        if mode_code in self._PRESET_CODES:
+            return self._last_hvac_mode
+        hvac = self._MODE_TO_HVAC.get(mode_code)
+        if hvac is not None:
+            self._last_hvac_mode = hvac
+        return hvac
+
+    @property
+    def preset_mode(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        mode_code = self.coordinator.data["mode"]
+        return self._PRESET_CODES.get(mode_code, AC_PRESET_NONE)
+
+    @property
+    def target_temperature(self) -> float | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("set_temp_c")
+
+    @property
+    def fan_mode(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        return str(self.coordinator.data["fan_speed"])
+
+    @property
+    def swing_mode(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        # Protocol: 1 = start swing, 2 = stop swing.
+        return "on" if self.coordinator.data["swing"] == 1 else "off"
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        if hvac_mode == HVACMode.OFF:
+            await self.coordinator._client.send_command(0x01, bytes([0x01]))
+        else:
+            # Power on first if currently off, then set mode.
+            if self.hvac_mode == HVACMode.OFF:
+                await self.coordinator._client.send_command(0x01, bytes([0x02]))
+            mode_map = {
+                HVACMode.COOL: _AC_MODE_COOL,
+                HVACMode.HEAT: _AC_MODE_HEAT,
+                HVACMode.FAN_ONLY: _AC_MODE_FAN,
+                HVACMode.DRY: _AC_MODE_DEHUMIDIFY,
+            }
+            code = mode_map.get(hvac_mode)
+            if code is not None:
+                await self.coordinator._client.send_command(0x02, bytes([code]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        if preset_mode == AC_PRESET_NONE:
+            # Restore the last base HVAC mode.
+            mode_map = {
+                HVACMode.COOL: _AC_MODE_COOL,
+                HVACMode.HEAT: _AC_MODE_HEAT,
+                HVACMode.FAN_ONLY: _AC_MODE_FAN,
+                HVACMode.DRY: _AC_MODE_DEHUMIDIFY,
+            }
+            code = mode_map.get(self._last_hvac_mode, _AC_MODE_COOL)
+            await self.coordinator._client.send_command(0x02, bytes([code]))
+        else:
+            preset_map = {
+                AC_PRESET_ENERGY_SAVING: _AC_MODE_ENERGY_SAVING,
+                AC_PRESET_SLEEP: _AC_MODE_SLEEP,
+                AC_PRESET_TURBO: _AC_MODE_TURBO,
+            }
+            code = preset_map.get(preset_mode)
+            if code is not None:
+                await self.coordinator._client.send_command(0x02, bytes([code]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        temp_c = kwargs.get("temperature")
+        if temp_c is None:
+            return
+        if self.coordinator.temp_unit == UnitOfTemperature.FAHRENHEIT:
+            value = round(celsius_to_fahrenheit(temp_c))
+        else:
+            value = round(temp_c)
+        await self.coordinator._client.send_command(0x03, bytes([value]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        await self.coordinator._client.send_command(0x04, bytes([int(fan_mode)]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        # Protocol: 0x01 = start swing, 0x02 = stop swing.
+        value = 0x01 if swing_mode == "on" else 0x02
+        await self.coordinator._client.send_command(0x10, bytes([value]))
+        await self.coordinator.async_request_refresh()

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -82,9 +82,8 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     """Climate entity for a Velit heater (protocol V1.02).
 
     HVAC modes:
-      OFF       — heater is shut down
-      HEAT      — heater running (manual or thermostat preset)
-      FAN_ONLY  — ventilation only (func 0x03 / 0x04)
+      OFF   — heater is shut down
+      HEAT  — heater running (manual or thermostat preset)
 
     Presets (only meaningful in HEAT mode):
       manual      — fixed gear, no thermostat
@@ -93,7 +92,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     Fan modes: gear levels 1–5 (only meaningful in manual mode).
     """
 
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.FAN_ONLY]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
     _attr_preset_modes = ["manual", "thermostat"]
     _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -132,10 +131,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         state = self.coordinator.data["machine_state"]
         if state == 0:
             return HVACMode.OFF
-        work_mode = self.coordinator.data["work_mode"]
-        # Gear 0 with no work mode implies ventilation only.
-        if work_mode == 0:
-            return HVACMode.FAN_ONLY
         return HVACMode.HEAT
 
     @property
@@ -203,8 +198,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator._client.send_command(0x02, bytes([0x00]))
-        elif hvac_mode == HVACMode.FAN_ONLY:
-            await self.coordinator._client.send_command(0x03, bytes([0x00]))
         elif hvac_mode == HVACMode.HEAT:
             # Start in the currently selected preset mode.
             mode_byte = (

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -17,6 +17,7 @@ from typing import Any
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -163,6 +164,37 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         if self.coordinator.data is None:
             return None
         return str(self.coordinator.data["current_gear"])
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Current action shown on the climate card.
+
+        Maps machine state and fault code to an HVACAction so the climate card
+        reflects what the device is doing, not just what mode it is set to.
+        """
+        if self.coordinator.data is None:
+            return None
+        # Any active fault — device is not operational.
+        if self.coordinator.data["fault_code"] != 0:
+            return HVACAction.OFF
+        state = self.coordinator.data["machine_state"]
+        if state == 1:
+            return HVACAction.HEATING
+        if state == 2:
+            # Fan running to cool combustion chamber after shutdown.
+            return HVACAction.FAN
+        # Standby, overtemp standby, cleaning, clean complete — no active output.
+        return HVACAction.IDLE
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose machine state and fault as automation-accessible attributes."""
+        if self.coordinator.data is None:
+            return {}
+        return {
+            "machine_state": self.coordinator.data.get("machine_state_str"),
+            "fault": self.coordinator.data.get("fault_name"),
+        }
 
     # ------------------------------------------------------------------
     # Actions — send command then refresh to confirm state

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -181,8 +181,6 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
         if q2 is None:
             raise UpdateFailed("No response to Query 2 (0x0B)")
 
-        _LOGGER.debug("Q1 raw data: %s", q1["data"].hex())
-        _LOGGER.debug("Q2 raw data: %s", q2["data"].hex())
         return self._parse(q1["data"], q2["data"])
 
     def _parse(self, q1_data: bytes, q2_data: bytes) -> dict:

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -181,6 +181,8 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
         if q2 is None:
             raise UpdateFailed("No response to Query 2 (0x0B)")
 
+        _LOGGER.debug("Q1 raw data: %s", q1["data"].hex())
+        _LOGGER.debug("Q2 raw data: %s", q2["data"].hex())
         return self._parse(q1["data"], q2["data"])
 
     def _parse(self, q1_data: bytes, q2_data: bytes) -> dict:

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -1,0 +1,306 @@
+"""DataUpdateCoordinator implementations for Velit heater and AC devices.
+
+Both coordinators share a common base that handles connection lifecycle and
+temperature unit detection. Subclasses override _async_poll() to issue the
+device-specific queries and return a data dict.
+
+Temperature unit detection (on first connect):
+  Query the device's current setpoint. If the value falls in 16–30 it is in
+  Celsius mode; 61–86 means Fahrenheit. Anything else falls back to the HA
+  system unit preference (hass.config.units.temperature_unit). The detected
+  unit is stored and used for all subsequent SET commands and sensor decoding.
+  We never send a value that would flip the device's display unit.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from datetime import timedelta
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .ac_client import VelitACClient
+from .heater_client import VelitHeaterClient
+from .packet_utils import fahrenheit_to_celsius
+
+_LOGGER = logging.getLogger(__name__)
+
+POLL_INTERVAL = timedelta(seconds=30)
+
+# Setpoint ranges used to infer whether the device is in Celsius or Fahrenheit mode.
+# These ranges are non-overlapping so the unit can be determined unambiguously.
+_CELSIUS_SETPOINT_MIN = 16
+_CELSIUS_SETPOINT_MAX = 30
+_FAHRENHEIT_SETPOINT_MIN = 61
+_FAHRENHEIT_SETPOINT_MAX = 86
+
+# Heater fault codes from protocol V1.02.
+HEATER_FAULT_CODES: dict[int, str] = {
+    0: "No Fault",
+    1: "Ignition Failure",
+    2: "Abnormal Flame Out",
+    3: "Voltage Deviation",
+    4: "Heat Exchanger Temp Anomaly",
+    5: "Ignition Sensor Fault",
+    6: "Outlet Temp Sensor Fault",
+    7: "Fuel Pump Fault",
+    8: "Fan Fault",
+    9: "Inlet Temp Sensor Fault",
+    10: "Glow Plug Fault",
+    11: "Operating Ambient Temp Anomaly",
+    12: "Altitude Out of Range",
+    13: "Fan Blockage Fault",
+    14: "CO Pollution Exceeded",
+    15: "LIN Communication Fault",
+}
+
+# Heater machine states from Query 1 response (offset 3 of data payload).
+HEATER_MACHINE_STATES: dict[int, str] = {
+    0: "Standby",
+    1: "Normal",
+    2: "Cooling Down",
+    3: "Overtemp Standby",
+    4: "Cleaning",
+    5: "Clean Complete",
+}
+
+
+class _VelitBaseCoordinator(DataUpdateCoordinator):
+    """Shared base for Velit coordinators.
+
+    Manages connect/disconnect lifecycle and temperature unit detection.
+    Subclasses implement _async_poll() to issue device-specific queries.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        name: str,
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=name,
+            update_interval=POLL_INTERVAL,
+            always_update=False,
+        )
+        self._entry = entry
+        self._address: str = entry.data["address"]
+        # Detected on first connect — preserved for the lifetime of the entry.
+        self.temp_unit: str = UnitOfTemperature.CELSIUS
+
+    async def async_connect(self) -> None:
+        """Connect the BLE client. Called from async_setup_entry."""
+        await self._client.connect()  # type: ignore[attr-defined]
+
+    async def async_disconnect(self) -> None:
+        """Disconnect the BLE client. Called from async_unload_entry."""
+        await self._client.disconnect()  # type: ignore[attr-defined]
+
+    def _detect_temp_unit(self, setpoint: int) -> str:
+        """Infer device temperature unit from the current setpoint value.
+
+        Returns UnitOfTemperature.CELSIUS or FAHRENHEIT. Falls back to the
+        HA system unit when the setpoint is outside both known ranges (e.g.
+        on first boot or after a fault reset where the value is 0x00).
+        """
+        if _CELSIUS_SETPOINT_MIN <= setpoint <= _CELSIUS_SETPOINT_MAX:
+            return UnitOfTemperature.CELSIUS
+        if _FAHRENHEIT_SETPOINT_MIN <= setpoint <= _FAHRENHEIT_SETPOINT_MAX:
+            return UnitOfTemperature.FAHRENHEIT
+        # Indeterminate — honour whatever the user has configured in HA.
+        ha_unit = self.hass.config.units.temperature_unit
+        _LOGGER.debug(
+            "Setpoint %d outside both unit ranges; falling back to HA system unit %s",
+            setpoint,
+            ha_unit,
+        )
+        return ha_unit
+
+    def to_celsius(self, value: float) -> float:
+        """Convert a value in the device's active unit to Celsius for HA reporting."""
+        if self.temp_unit == UnitOfTemperature.FAHRENHEIT:
+            return fahrenheit_to_celsius(value)
+        return float(value)
+
+    @abstractmethod
+    async def _async_poll(self) -> dict:
+        """Issue device queries and return a data dict. Raise UpdateFailed on error."""
+
+    async def _async_update_data(self) -> dict:
+        """Called by DataUpdateCoordinator on each poll cycle."""
+        try:
+            return await self._async_poll()
+        except UpdateFailed:
+            raise
+        except Exception as exc:
+            raise UpdateFailed(f"Unexpected error polling {self._address}: {exc}") from exc
+
+
+class VelitHeaterCoordinator(_VelitBaseCoordinator):
+    """Coordinator for Velit heater devices (protocol V1.02).
+
+    Polls Query 1 (0x0A) for device state and Query 2 (0x0B) for sensor
+    readings on each cycle. Temperature unit is detected from the Query 1
+    setpoint on first connect.
+
+    Data dict keys:
+      fault_code        int     — raw fault code (0 = no fault)
+      fault_name        str     — human-readable fault description
+      work_mode         int     — 1 = Manual, 2 = Thermostat
+      current_gear      int     — 1–5
+      set_temp_c        float   — target temperature in Celsius
+      machine_state     int     — raw machine state code
+      machine_state_str str     — human-readable machine state
+      heater_power_w    int     — heater power in Watts
+      fuel_pump_hz      float   — fuel pump frequency in Hz
+      voltage_v         float | None  — supply voltage in V (None if unavailable)
+      fan_rpm           int | None    — fan speed in RPM (None if unavailable)
+      inlet_temp_c      float | None  — inlet temperature in Celsius (None if unavailable)
+      casing_temp_c     float | None  — casing temperature in Celsius (None if unavailable)
+      outlet_temp_c     float | None  — outlet temperature in Celsius (None if unavailable)
+      altitude          int | None    — altitude in device unit (None if unavailable)
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        super().__init__(hass, entry, name=f"Velit Heater {entry.data['address']}")
+        self._client = VelitHeaterClient(self._address)
+        self._unit_detected = False
+
+    async def _async_poll(self) -> dict:
+        q1 = await self._client.send_command(0x0A, bytes([0x00]))
+        if q1 is None:
+            raise UpdateFailed("No response to Query 1 (0x0A)")
+
+        q2 = await self._client.send_command(0x0B, bytes([0x00]))
+        if q2 is None:
+            raise UpdateFailed("No response to Query 2 (0x0B)")
+
+        return self._parse(q1["data"], q2["data"])
+
+    def _parse(self, q1_data: bytes, q2_data: bytes) -> dict:
+        """Parse Query 1 and Query 2 data payloads into a normalised data dict."""
+        # Query 1 layout: [fault][work_mode][gear][set_temp][machine_state][power][pump_freq]
+        fault_code = q1_data[0]
+        work_mode = q1_data[1]
+        current_gear = q1_data[2]
+        set_temp_raw = q1_data[3]
+        machine_state = q1_data[4]
+        heater_power_w = q1_data[5]
+        fuel_pump_hz = q1_data[6] / 10.0
+
+        # Detect unit on first successful poll.
+        if not self._unit_detected:
+            self.temp_unit = self._detect_temp_unit(set_temp_raw)
+            self._unit_detected = True
+            _LOGGER.debug("Heater %s: detected temp unit %s", self._address, self.temp_unit)
+
+        set_temp_c = self.to_celsius(set_temp_raw)
+
+        # Query 2 layout: [fault][voltage 2B][fan_rpm 2B][inlet 2B][casing 2B][outlet 2B][alt 2B]
+        # Each sensor pair is big-endian unsigned int. 0xFFFF = sensor unavailable.
+        def _read_u16(data: bytes, offset: int) -> int:
+            return (data[offset] << 8) | data[offset + 1]
+
+        def _sensor_temp(raw: int) -> float | None:
+            if raw == 0xFFFF:
+                return None
+            # Protocol offset encoding: raw - 50 = °C, raw - 60 = °F.
+            if self.temp_unit == UnitOfTemperature.FAHRENHEIT:
+                return float(raw - 60)
+            return float(raw - 50)
+
+        voltage_raw = _read_u16(q2_data, 1)   # offset 0 = fault byte, skip
+        fan_raw = _read_u16(q2_data, 3)
+        inlet_raw = _read_u16(q2_data, 5)
+        casing_raw = _read_u16(q2_data, 7)
+        outlet_raw = _read_u16(q2_data, 9)
+        alt_raw = _read_u16(q2_data, 11)
+
+        inlet_native = _sensor_temp(inlet_raw)
+        casing_native = _sensor_temp(casing_raw)
+        outlet_native = _sensor_temp(outlet_raw)
+
+        return {
+            "fault_code": fault_code,
+            "fault_name": HEATER_FAULT_CODES.get(fault_code, f"Unknown ({fault_code})"),
+            "work_mode": work_mode,
+            "current_gear": current_gear,
+            "set_temp_c": set_temp_c,
+            "machine_state": machine_state,
+            "machine_state_str": HEATER_MACHINE_STATES.get(machine_state, f"Unknown ({machine_state})"),
+            "heater_power_w": heater_power_w,
+            "fuel_pump_hz": fuel_pump_hz,
+            "voltage_v": voltage_raw / 10.0 if voltage_raw != 0xFFFF else None,
+            "fan_rpm": fan_raw if fan_raw != 0xFFFF else None,
+            "inlet_temp_c": self.to_celsius(inlet_native) if inlet_native is not None else None,
+            "casing_temp_c": self.to_celsius(casing_native) if casing_native is not None else None,
+            "outlet_temp_c": self.to_celsius(outlet_native) if outlet_native is not None else None,
+            "altitude": alt_raw if alt_raw != 0xFFFF else None,
+        }
+
+
+class VelitACCoordinator(_VelitBaseCoordinator):
+    """Coordinator for Velit AC devices (protocol V1.01).
+
+    Polls mode (0x02), temperature (0x03), fan speed (0x04), swing (0x10),
+    inlet air temperature (0x07), and fault info (0x0B) on each cycle.
+
+    Inlet temperature and fault response formats are not fully documented —
+    both are queried and the raw response is stored. Decoded values will be
+    added once response formats are confirmed via hardware capture.
+
+    Data dict keys:
+      mode              int     — current operation mode code (see AC protocol 0x02)
+      set_temp_c        float   — current setpoint in Celsius
+      fan_speed         int     — current fan speed 1–5
+      swing             int     — 1 = swinging, 2 = stopped (raw device value)
+      inlet_temp_raw    bytes | None  — raw 0x07 response data (format unconfirmed)
+      fault_raw         bytes | None  — raw 0x0B response data (format unconfirmed)
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        super().__init__(hass, entry, name=f"Velit AC {entry.data['address']}")
+        self._client = VelitACClient(self._address)
+        self._unit_detected = False
+
+    async def _async_poll(self) -> dict:
+        mode_rsp = await self._client.send_command(0x02, bytes([0x00]))
+        if mode_rsp is None:
+            raise UpdateFailed("No response to mode query (0x02)")
+
+        temp_rsp = await self._client.send_command(0x03, bytes([0x00]))
+        if temp_rsp is None:
+            raise UpdateFailed("No response to temperature query (0x03)")
+
+        fan_rsp = await self._client.send_command(0x04, bytes([0x00]))
+        if fan_rsp is None:
+            raise UpdateFailed("No response to fan speed query (0x04)")
+
+        swing_rsp = await self._client.send_command(0x10, bytes([0x00]))
+        if swing_rsp is None:
+            raise UpdateFailed("No response to swing query (0x10)")
+
+        # Inlet temp and fault formats unconfirmed — log raw, do not raise on failure.
+        inlet_rsp = await self._client.send_command(0x07, bytes([0x00]))
+        fault_rsp = await self._client.send_command(0x0B, bytes([0x00]))
+
+        set_temp_raw = temp_rsp["data"][0]
+        if not self._unit_detected:
+            self.temp_unit = self._detect_temp_unit(set_temp_raw)
+            self._unit_detected = True
+            _LOGGER.debug("AC %s: detected temp unit %s", self._address, self.temp_unit)
+
+        return {
+            "mode": mode_rsp["data"][0],
+            "set_temp_c": self.to_celsius(set_temp_raw),
+            "fan_speed": fan_rsp["data"][0],
+            "swing": swing_rsp["data"][0],
+            "inlet_temp_raw": inlet_rsp["data"] if inlet_rsp else None,
+            "fault_raw": fault_rsp["data"] if fault_rsp else None,
+        }

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -182,12 +182,23 @@ class VelitHeaterClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        self._client = BleakClient(
+        client = BleakClient(
             self._address,
             disconnected_callback=self._on_disconnect,
         )
-        await self._client.connect()
-        await self._client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        self._client = client
+        try:
+            await client.connect()
+            await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
+        except Exception:
+            # Disconnect before re-raising so BlueZ releases this connection and
+            # any stale notification subscription — prevents "Notify acquired" on
+            # the next attempt.
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+            raise
         self._connected = True
         self._queue_task = asyncio.create_task(self._queue_runner())
         _LOGGER.info("Connected to %s", self._address)
@@ -288,6 +299,11 @@ class VelitHeaterClient:
 
     def _on_disconnect(self, _client: BleakClient) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
+        if not self._connected:
+            # The disconnect fired during a failed connect() attempt —
+            # _connected was never set True. connect() handles its own cleanup;
+            # do not start a reconnect loop here.
+            return
         self._connected = False
         _LOGGER.warning("Connection lost to %s", self._address)
         # Cancel any in-flight command future so the caller does not hang.

--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -7,6 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JohnFreeborg/velit-hass/issues",
+  "dependencies": ["bluetooth"],
   "requirements": [],
   "version": "0.0.1",
   "bluetooth": [

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -7,6 +7,8 @@ Heater sensors (all sourced from coordinator data):
   - Supply voltage
   - Fan RPM
   - Altitude
+  - Fuel pump frequency (Hz)
+  - Heater power (W)
   - Fault code (human-readable string)
   - Machine state (human-readable string)
 
@@ -32,6 +34,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
     UnitOfElectricPotential,
+    UnitOfFrequency,
+    UnitOfPower,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
@@ -101,6 +105,24 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         # Unit depends on the device's active temperature unit (metric vs imperial).
         # Set dynamically in VelitHeaterSensorEntity based on coordinator.temp_unit.
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="fuel_pump_freq",
+        data_key="fuel_pump_hz",
+        name="Fuel Pump Frequency",
+        device_class=SensorDeviceClass.FREQUENCY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="heater_power",
+        data_key="heater_power_w",
+        name="Heater Power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     VelitSensorEntityDescription(

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -129,7 +129,6 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         key="fault_code",
         data_key="fault_name",
         name="Fault",
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     VelitSensorEntityDescription(
         key="machine_state",

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -1,0 +1,202 @@
+"""Sensor entities for Velit heater and AC devices.
+
+Heater sensors (all sourced from coordinator data):
+  - Inlet temperature
+  - Casing temperature
+  - Outlet temperature
+  - Supply voltage
+  - Fan RPM
+  - Altitude
+  - Fault code (human-readable string)
+  - Machine state (human-readable string)
+
+AC sensors:
+  - Fault info (raw bytes, pending format confirmation via hardware capture)
+
+All temperature sensors report in Celsius — the coordinator converts from
+the device's active unit before storing values in the data dict.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_NAME,
+    UnitOfElectricPotential,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DEVICE_TYPE_HEATER, DOMAIN
+from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class VelitSensorEntityDescription(SensorEntityDescription):
+    """Extends SensorEntityDescription with the coordinator data key."""
+    data_key: str = ""
+
+
+# Sensor descriptors for all heater sensors.
+HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
+    VelitSensorEntityDescription(
+        key="inlet_temp",
+        data_key="inlet_temp_c",
+        name="Inlet Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    VelitSensorEntityDescription(
+        key="casing_temp",
+        data_key="casing_temp_c",
+        name="Casing Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    VelitSensorEntityDescription(
+        key="outlet_temp",
+        data_key="outlet_temp_c",
+        name="Outlet Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    VelitSensorEntityDescription(
+        key="voltage",
+        data_key="voltage_v",
+        name="Supply Voltage",
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="fan_rpm",
+        data_key="fan_rpm",
+        name="Fan Speed",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="RPM",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="altitude",
+        data_key="altitude",
+        name="Altitude",
+        state_class=SensorStateClass.MEASUREMENT,
+        # Unit depends on the device's active temperature unit (metric vs imperial).
+        # Set dynamically in VelitHeaterSensorEntity based on coordinator.temp_unit.
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="fault_code",
+        data_key="fault_name",
+        name="Fault",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VelitSensorEntityDescription(
+        key="machine_state",
+        data_key="machine_state_str",
+        name="Machine State",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Velit sensor entities from a config entry."""
+    coordinator = entry.runtime_data
+
+    if entry.data["device_type"] == DEVICE_TYPE_HEATER:
+        async_add_entities(
+            VelitHeaterSensorEntity(coordinator, entry, description)
+            for description in HEATER_SENSORS
+        )
+    else:
+        async_add_entities([VelitACFaultSensorEntity(coordinator, entry)])
+
+
+class VelitHeaterSensorEntity(CoordinatorEntity[VelitHeaterCoordinator], SensorEntity):
+    """A single sensor entity reading from the heater coordinator data dict."""
+
+    entity_description: VelitSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+        description: VelitSensorEntityDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.data['address']}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+        # Altitude unit is set once the coordinator has detected the device unit.
+        if description.key == "altitude":
+            self._attr_native_unit_of_measurement = (
+                "ft" if coordinator.temp_unit == UnitOfTemperature.FAHRENHEIT else "m"
+            )
+
+    @property
+    def native_value(self) -> float | int | str | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get(self.entity_description.data_key)
+
+
+class VelitACFaultSensorEntity(CoordinatorEntity[VelitACCoordinator], SensorEntity):
+    """Exposes raw AC fault query response pending format confirmation.
+
+    The AC protocol document lists func 0x0B as 'System Fault Info' but does
+    not provide a response format or fault code table. This sensor stores the
+    raw response bytes as a hex string until the format is confirmed via
+    hardware capture and a proper decoder can be added.
+    """
+
+    _attr_name = "Fault Info (raw)"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: VelitACCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_fault_raw"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+
+    @property
+    def native_value(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        raw = self.coordinator.data.get("fault_raw")
+        if raw is None:
+            return None
+        return raw.hex()

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -40,5 +40,36 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "inlet_temp": {
+        "name": "Inlet Temperature"
+      },
+      "casing_temp": {
+        "name": "Casing Temperature"
+      },
+      "outlet_temp": {
+        "name": "Outlet Temperature"
+      },
+      "voltage": {
+        "name": "Supply Voltage"
+      },
+      "fan_rpm": {
+        "name": "Fan Speed"
+      },
+      "altitude": {
+        "name": "Altitude"
+      },
+      "fault_code": {
+        "name": "Fault"
+      },
+      "machine_state": {
+        "name": "Machine State"
+      },
+      "fault_raw": {
+        "name": "Fault Info (raw)"
+      }
+    }
   }
 }

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -42,6 +42,14 @@
     }
   },
   "entity": {
+    "button": {
+      "prime_fuel_pump": {
+        "name": "Prime Fuel Pump"
+      },
+      "cleaning": {
+        "name": "Clean (Residual Fuel Clearance)"
+      }
+    },
     "sensor": {
       "inlet_temp": {
         "name": "Inlet Temperature"
@@ -60,6 +68,12 @@
       },
       "altitude": {
         "name": "Altitude"
+      },
+      "fuel_pump_freq": {
+        "name": "Fuel Pump Frequency"
+      },
+      "heater_power": {
+        "name": "Heater Power"
       },
       "fault_code": {
         "name": "Fault"

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -40,5 +40,36 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "inlet_temp": {
+        "name": "Inlet Temperature"
+      },
+      "casing_temp": {
+        "name": "Casing Temperature"
+      },
+      "outlet_temp": {
+        "name": "Outlet Temperature"
+      },
+      "voltage": {
+        "name": "Supply Voltage"
+      },
+      "fan_rpm": {
+        "name": "Fan Speed"
+      },
+      "altitude": {
+        "name": "Altitude"
+      },
+      "fault_code": {
+        "name": "Fault"
+      },
+      "machine_state": {
+        "name": "Machine State"
+      },
+      "fault_raw": {
+        "name": "Fault Info (raw)"
+      }
+    }
   }
 }

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -42,6 +42,14 @@
     }
   },
   "entity": {
+    "button": {
+      "prime_fuel_pump": {
+        "name": "Prime Fuel Pump"
+      },
+      "cleaning": {
+        "name": "Clean (Residual Fuel Clearance)"
+      }
+    },
     "sensor": {
       "inlet_temp": {
         "name": "Inlet Temperature"
@@ -60,6 +68,12 @@
       },
       "altitude": {
         "name": "Altitude"
+      },
+      "fuel_pump_freq": {
+        "name": "Fuel Pump Frequency"
+      },
+      "heater_power": {
+        "name": "Heater Power"
       },
       "fault_code": {
         "name": "Fault"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 # Shared fixtures for the Velit integration test suite.
 
+from unittest.mock import patch
+
 import pytest
-from homeassistant.core import HomeAssistant
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -9,3 +10,19 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations: None) -> None:
     """Enable custom integration loading for all tests in this suite."""
+
+
+@pytest.fixture(autouse=True)
+def mock_bluetooth_adapters() -> None:
+    """Prevent the bluetooth component from trying to access BlueZ/dbus.
+
+    The bluetooth dependency in manifest.json causes HA to set up the bluetooth
+    component during config flow tests. On non-Linux systems (macOS, CI) the
+    adapter history call fails because BlueZ/dbus is unavailable. Patching it
+    to return empty state lets the component set up cleanly without hardware.
+    """
+    with patch(
+        "homeassistant.components.bluetooth.util.async_load_history_from_system",
+        return_value=({}, {}),
+    ):
+        yield

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,158 @@
+"""Unit tests for VelitHeaterPrimeFuelPumpButton and VelitHeaterCleaningButton.
+
+Coordinator client is mocked — tests verify correct commands are sent and that
+the prime toggle logic (start / auto-stop / early-stop) behaves as expected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from custom_components.velit.button import (
+    VelitHeaterCleaningButton,
+    VelitHeaterPrimeFuelPumpButton,
+    _PRIME_AUTO_STOP_SECONDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(address="AA:BB:CC:DD:EE:FF"):
+    entry = MagicMock()
+    entry.data = {"device_type": "heater", "address": address, "name": "Test Heater"}
+    return entry
+
+
+def _make_coord():
+    coord = MagicMock()
+    coord._client = MagicMock()
+    coord._client.send_command = AsyncMock()
+    return coord
+
+
+def _make_prime_button():
+    coord = _make_coord()
+    entry = _make_entry()
+    button = VelitHeaterPrimeFuelPumpButton(coord, entry)
+    return button, coord
+
+
+def _make_cleaning_button():
+    coord = _make_coord()
+    entry = _make_entry()
+    button = VelitHeaterCleaningButton(coord, entry)
+    return button, coord
+
+
+# ---------------------------------------------------------------------------
+# Prime button — start and auto-stop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prime_sends_start_command():
+    button, coord = _make_prime_button()
+    with patch("asyncio.create_task") as mock_task:
+        await button.async_press()
+    coord._client.send_command.assert_awaited_once_with(0x05, bytes([0x00]))
+
+
+@pytest.mark.asyncio
+async def test_prime_creates_auto_stop_task():
+    button, coord = _make_prime_button()
+    with patch("asyncio.create_task") as mock_task:
+        await button.async_press()
+    mock_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_prime_auto_stop_sends_stop_command():
+    button, coord = _make_prime_button()
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await button._auto_stop()
+    coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
+
+
+@pytest.mark.asyncio
+async def test_prime_auto_stop_clears_task_reference():
+    button, coord = _make_prime_button()
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await button._auto_stop()
+    assert button._prime_task is None
+
+
+# ---------------------------------------------------------------------------
+# Prime button — early stop (press again while priming)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prime_early_stop_cancels_task_and_sends_stop():
+    button, coord = _make_prime_button()
+
+    # Simulate an in-progress prime task.
+    mock_task = MagicMock(spec=asyncio.Task)
+    mock_task.done.return_value = False
+    button._prime_task = mock_task
+
+    await button.async_press()
+
+    mock_task.cancel.assert_called_once()
+    coord._client.send_command.assert_awaited_once_with(0x06, bytes([0x00]))
+
+
+@pytest.mark.asyncio
+async def test_prime_early_stop_clears_task_reference():
+    button, coord = _make_prime_button()
+
+    mock_task = MagicMock(spec=asyncio.Task)
+    mock_task.done.return_value = False
+    button._prime_task = mock_task
+
+    await button.async_press()
+
+    assert button._prime_task is None
+
+
+@pytest.mark.asyncio
+async def test_prime_press_after_completed_task_starts_new_prime():
+    """A completed (done) task is not treated as in-progress."""
+    button, coord = _make_prime_button()
+
+    completed_task = MagicMock(spec=asyncio.Task)
+    completed_task.done.return_value = True
+    button._prime_task = completed_task
+
+    with patch("asyncio.create_task"):
+        await button.async_press()
+
+    # Should have started, not stopped.
+    coord._client.send_command.assert_awaited_once_with(0x05, bytes([0x00]))
+
+
+# ---------------------------------------------------------------------------
+# Cleaning button
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cleaning_sends_correct_command():
+    button, coord = _make_cleaning_button()
+    await button.async_press()
+    coord._client.send_command.assert_awaited_once_with(0x09, bytes([0x00]))
+
+
+# ---------------------------------------------------------------------------
+# Entity metadata
+# ---------------------------------------------------------------------------
+
+def test_prime_button_unique_id():
+    button, _ = _make_prime_button()
+    assert button.unique_id == "AA:BB:CC:DD:EE:FF_prime_fuel_pump"
+
+
+def test_cleaning_button_unique_id():
+    button, _ = _make_cleaning_button()
+    assert button.unique_id == "AA:BB:CC:DD:EE:FF_cleaning"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,327 @@
+"""Unit tests for VelitHeaterClimateEntity and VelitACClimateEntity.
+
+Coordinator is mocked — tests verify that the correct commands are sent
+for each action and that state properties read correctly from coordinator data.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.components.climate import HVACMode
+from homeassistant.const import UnitOfTemperature
+
+from custom_components.velit.climate import (
+    VelitACClimateEntity,
+    VelitHeaterClimateEntity,
+    AC_PRESET_ENERGY_SAVING,
+    AC_PRESET_NONE,
+    AC_PRESET_SLEEP,
+    AC_PRESET_TURBO,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(device_type="heater", address="AA:BB:CC:DD:EE:FF"):
+    entry = MagicMock()
+    entry.data = {"device_type": device_type, "address": address, "name": "Test Heater"}
+    return entry
+
+
+_UNSET = object()
+
+
+def _make_heater_coord(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
+    coord = MagicMock()
+    coord.data = data if data is not _UNSET else {
+        "fault_code": 0,
+        "fault_name": "No Fault",
+        "work_mode": 1,
+        "current_gear": 3,
+        "set_temp_c": 22.0,
+        "machine_state": 1,
+        "machine_state_str": "Normal",
+        "heater_power_w": 80,
+        "fuel_pump_hz": 0.5,
+        "voltage_v": 12.7,
+        "fan_rpm": 0,
+        "inlet_temp_c": 21.7,
+        "casing_temp_c": 16.7,
+        "outlet_temp_c": 11.7,
+        "altitude": 1415,
+    }
+    coord.temp_unit = temp_unit
+    coord.async_request_refresh = AsyncMock()
+    coord._client = MagicMock()
+    coord._client.send_command = AsyncMock()
+    return coord
+
+
+def _make_ac_coord(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
+    coord = MagicMock()
+    coord.data = data if data is not _UNSET else {
+        "mode": 1,
+        "set_temp_c": 22.0,
+        "fan_speed": 3,
+        "swing": 2,
+        "inlet_temp_raw": None,
+        "fault_raw": None,
+    }
+    coord.temp_unit = temp_unit
+    coord.async_request_refresh = AsyncMock()
+    coord._client = MagicMock()
+    coord._client.send_command = AsyncMock()
+    return coord
+
+
+def _heater_entity(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
+    coord = _make_heater_coord(data, temp_unit)
+    entry = _make_entry()
+    entity = VelitHeaterClimateEntity.__new__(VelitHeaterClimateEntity)
+    entity.coordinator = coord
+    entity._entry = entry
+    entity._attr_unique_id = "test_climate"
+    entity._attr_name = "Test Heater"
+    entity._attr_device_info = MagicMock()
+    return entity, coord
+
+
+def _ac_entity(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
+    coord = _make_ac_coord(data, temp_unit)
+    entry = _make_entry(device_type="ac")
+    entity = VelitACClimateEntity.__new__(VelitACClimateEntity)
+    entity.coordinator = coord
+    entity._entry = entry
+    entity._attr_unique_id = "test_climate_ac"
+    entity._attr_name = "Test AC"
+    entity._attr_device_info = MagicMock()
+    entity._last_hvac_mode = HVACMode.COOL
+    return entity, coord
+
+
+# ---------------------------------------------------------------------------
+# Heater — state properties
+# ---------------------------------------------------------------------------
+
+
+class TestHeaterClimateState:
+    def test_hvac_mode_off_when_standby(self):
+        entity, _ = _heater_entity(data={**_make_heater_coord().data, "machine_state": 0})
+        assert entity.hvac_mode == HVACMode.OFF
+
+    def test_hvac_mode_heat_when_running(self):
+        entity, _ = _heater_entity()
+        assert entity.hvac_mode == HVACMode.HEAT
+
+    def test_preset_manual(self):
+        entity, _ = _heater_entity()
+        assert entity.preset_mode == "manual"
+
+    def test_preset_thermostat(self):
+        data = {**_make_heater_coord().data, "work_mode": 2}
+        entity, _ = _heater_entity(data=data)
+        assert entity.preset_mode == "thermostat"
+
+    def test_current_temperature(self):
+        entity, _ = _heater_entity()
+        assert entity.current_temperature == pytest.approx(21.7)
+
+    def test_target_temperature(self):
+        entity, _ = _heater_entity()
+        assert entity.target_temperature == pytest.approx(22.0)
+
+    def test_fan_mode(self):
+        entity, _ = _heater_entity()
+        assert entity.fan_mode == "3"
+
+    def test_none_data_returns_none(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.hvac_mode is None
+        assert entity.current_temperature is None
+        assert entity.target_temperature is None
+        assert entity.fan_mode is None
+
+
+# ---------------------------------------------------------------------------
+# Heater — actions
+# ---------------------------------------------------------------------------
+
+
+class TestHeaterClimateActions:
+    async def test_set_hvac_off(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+        coord._client.send_command.assert_called_once_with(0x02, bytes([0x00]))
+        coord.async_request_refresh.assert_called_once()
+
+    async def test_set_hvac_fan_only(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
+        coord._client.send_command.assert_called_once_with(0x03, bytes([0x00]))
+
+    async def test_set_hvac_heat_manual(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_hvac_mode(HVACMode.HEAT)
+        coord._client.send_command.assert_called_once_with(0x01, bytes([0x01]))
+
+    async def test_set_hvac_heat_thermostat(self):
+        data = {**_make_heater_coord().data, "work_mode": 2}
+        entity, coord = _heater_entity(data=data)
+        await entity.async_set_hvac_mode(HVACMode.HEAT)
+        coord._client.send_command.assert_called_once_with(0x01, bytes([0x02]))
+
+    async def test_set_preset_thermostat(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_preset_mode("thermostat")
+        coord._client.send_command.assert_called_once_with(0x00, bytes([0x02]))
+
+    async def test_set_preset_manual(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_preset_mode("manual")
+        coord._client.send_command.assert_called_once_with(0x00, bytes([0x01]))
+
+    async def test_set_temperature_celsius(self):
+        entity, coord = _heater_entity(temp_unit=UnitOfTemperature.CELSIUS)
+        await entity.async_set_temperature(temperature=24.0)
+        coord._client.send_command.assert_called_once_with(0x08, bytes([24]))
+
+    async def test_set_temperature_converts_to_fahrenheit_for_f_device(self):
+        """Device is in °F mode — we must send °F to avoid flipping the LCD unit."""
+        entity, coord = _heater_entity(temp_unit=UnitOfTemperature.FAHRENHEIT)
+        # 24°C → 75.2°F → rounds to 75
+        await entity.async_set_temperature(temperature=24.0)
+        coord._client.send_command.assert_called_once_with(0x08, bytes([75]))
+
+    async def test_set_fan_mode(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_fan_mode("5")
+        coord._client.send_command.assert_called_once_with(0x07, bytes([5]))
+
+    async def test_refresh_called_after_each_action(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_fan_mode("2")
+        coord.async_request_refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AC — state properties
+# ---------------------------------------------------------------------------
+
+
+class TestACClimateState:
+    def test_hvac_mode_cool(self):
+        entity, _ = _ac_entity()
+        assert entity.hvac_mode == HVACMode.COOL
+
+    def test_hvac_mode_off(self):
+        data = {**_make_ac_coord().data, "mode": 0}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_mode == HVACMode.OFF
+
+    def test_hvac_mode_dry(self):
+        data = {**_make_ac_coord().data, "mode": 7}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_mode == HVACMode.DRY
+
+    def test_preset_none_for_base_modes(self):
+        entity, _ = _ac_entity()
+        assert entity.preset_mode == AC_PRESET_NONE
+
+    def test_preset_energy_saving(self):
+        data = {**_make_ac_coord().data, "mode": 4}
+        entity, _ = _ac_entity(data=data)
+        assert entity.preset_mode == AC_PRESET_ENERGY_SAVING
+
+    def test_preset_sleep(self):
+        data = {**_make_ac_coord().data, "mode": 5}
+        entity, _ = _ac_entity(data=data)
+        assert entity.preset_mode == AC_PRESET_SLEEP
+
+    def test_preset_turbo(self):
+        data = {**_make_ac_coord().data, "mode": 6}
+        entity, _ = _ac_entity(data=data)
+        assert entity.preset_mode == AC_PRESET_TURBO
+
+    def test_swing_on(self):
+        data = {**_make_ac_coord().data, "swing": 1}
+        entity, _ = _ac_entity(data=data)
+        assert entity.swing_mode == "on"
+
+    def test_swing_off(self):
+        entity, _ = _ac_entity()
+        assert entity.swing_mode == "off"
+
+    def test_fan_mode(self):
+        entity, _ = _ac_entity()
+        assert entity.fan_mode == "3"
+
+
+# ---------------------------------------------------------------------------
+# AC — actions
+# ---------------------------------------------------------------------------
+
+
+class TestACClimateActions:
+    async def test_set_hvac_off(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+        coord._client.send_command.assert_called_once_with(0x01, bytes([0x01]))
+
+    async def test_set_hvac_cool(self):
+        entity, coord = _ac_entity(data={**_make_ac_coord().data, "mode": 0})
+        await entity.async_set_hvac_mode(HVACMode.COOL)
+        # Powers on first, then sets mode.
+        calls = coord._client.send_command.call_args_list
+        assert calls[0].args == (0x01, bytes([0x02]))
+        assert calls[1].args == (0x02, bytes([0x01]))
+
+    async def test_set_hvac_dry(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_hvac_mode(HVACMode.DRY)
+        coord._client.send_command.assert_called_once_with(0x02, bytes([0x07]))
+
+    async def test_set_preset_energy_saving(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_preset_mode(AC_PRESET_ENERGY_SAVING)
+        coord._client.send_command.assert_called_once_with(0x02, bytes([0x04]))
+
+    async def test_set_preset_none_restores_last_mode(self):
+        entity, coord = _ac_entity()
+        entity._last_hvac_mode = HVACMode.HEAT
+        await entity.async_set_preset_mode(AC_PRESET_NONE)
+        coord._client.send_command.assert_called_once_with(0x02, bytes([0x02]))
+
+    async def test_set_temperature_celsius(self):
+        entity, coord = _ac_entity(temp_unit=UnitOfTemperature.CELSIUS)
+        await entity.async_set_temperature(temperature=25.0)
+        coord._client.send_command.assert_called_once_with(0x03, bytes([25]))
+
+    async def test_set_temperature_fahrenheit_device(self):
+        entity, coord = _ac_entity(temp_unit=UnitOfTemperature.FAHRENHEIT)
+        # 25°C → 77°F
+        await entity.async_set_temperature(temperature=25.0)
+        coord._client.send_command.assert_called_once_with(0x03, bytes([77]))
+
+    async def test_set_fan_mode(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_fan_mode("4")
+        coord._client.send_command.assert_called_once_with(0x04, bytes([4]))
+
+    async def test_set_swing_on(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_swing_mode("on")
+        coord._client.send_command.assert_called_once_with(0x10, bytes([0x01]))
+
+    async def test_set_swing_off(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_swing_mode("off")
+        coord._client.send_command.assert_called_once_with(0x10, bytes([0x02]))
+
+    async def test_refresh_called_after_action(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_fan_mode("1")
+        coord.async_request_refresh.assert_called_once()

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from homeassistant.components.climate import HVACMode
+from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import UnitOfTemperature
 
 from custom_components.velit.climate import (
@@ -137,6 +137,40 @@ class TestHeaterClimateState:
     def test_fan_mode(self):
         entity, _ = _heater_entity()
         assert entity.fan_mode == "3"
+
+    def test_hvac_action_heating_when_normal(self):
+        data = {**_make_heater_coord().data, "machine_state": 1, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.HEATING
+
+    def test_hvac_action_fan_when_cooling_down(self):
+        data = {**_make_heater_coord().data, "machine_state": 2, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.FAN
+
+    def test_hvac_action_idle_when_standby(self):
+        data = {**_make_heater_coord().data, "machine_state": 0, "fault_code": 0}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.IDLE
+
+    def test_hvac_action_off_when_fault_active(self):
+        data = {**_make_heater_coord().data, "machine_state": 0, "fault_code": 1}
+        entity, _ = _heater_entity(data=data)
+        assert entity.hvac_action == HVACAction.OFF
+
+    def test_hvac_action_none_when_no_data(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.hvac_action is None
+
+    def test_extra_state_attributes_contains_machine_state_and_fault(self):
+        entity, _ = _heater_entity()
+        attrs = entity.extra_state_attributes
+        assert attrs["machine_state"] == "Normal"
+        assert attrs["fault"] == "No Fault"
+
+    def test_extra_state_attributes_empty_when_no_data(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.extra_state_attributes == {}
 
     def test_none_data_returns_none(self):
         entity, _ = _heater_entity(data=None)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -192,11 +192,6 @@ class TestHeaterClimateActions:
         coord._client.send_command.assert_called_once_with(0x02, bytes([0x00]))
         coord.async_request_refresh.assert_called_once()
 
-    async def test_set_hvac_fan_only(self):
-        entity, coord = _heater_entity()
-        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
-        coord._client.send_command.assert_called_once_with(0x03, bytes([0x00]))
-
     async def test_set_hvac_heat_manual(self):
         entity, coord = _heater_entity()
         await entity.async_set_hvac_mode(HVACMode.HEAT)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,9 +8,7 @@ No hardware required — HA test helpers provide mock BLE discovery objects.
 
 from __future__ import annotations
 
-from unittest.mock import patch
 
-import pytest
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_ADDRESS, CONF_NAME

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,292 @@
+"""Unit tests for VelitHeaterCoordinator and VelitACCoordinator.
+
+All BLE client calls are mocked — no hardware required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import UnitOfTemperature
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.velit.coordinator import (
+    VelitACCoordinator,
+    VelitHeaterCoordinator,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(device_type: str = "heater", address: str = "AA:BB:CC:DD:EE:FF"):
+    entry = MagicMock()
+    entry.data = {"device_type": device_type, "address": address, "name": "Test"}
+    return entry
+
+
+def _make_hass(temp_unit: str = UnitOfTemperature.CELSIUS):
+    hass = MagicMock()
+    hass.config.units.temperature_unit = temp_unit
+    return hass
+
+
+# Query 1 data payload for a heater in Fahrenheit mode (setpoint = 0x46 = 70°F).
+# Layout: [fault][work_mode][gear][set_temp][machine_state][power][pump_freq]
+Q1_DATA_F = bytes([0x00, 0x02, 0x05, 0x46, 0x01, 0x50, 0x00])
+
+# Query 1 data for a heater in Celsius mode (setpoint = 0x18 = 24°C).
+Q1_DATA_C = bytes([0x00, 0x01, 0x03, 0x18, 0x01, 0x32, 0x05])
+
+# Query 2 data payload.
+# Layout: [fault][voltage 2B][fan_rpm 2B][inlet 2B][casing 2B][outlet 2B][alt 2B]
+# Using hardware-verified values: voltage=12.7V, inlet=131 (71°F / raw-60), alt=1415.
+Q2_DATA = bytes([
+    0x00,           # fault
+    0x00, 0x7F,     # voltage = 127 → 12.7V
+    0x00, 0x00,     # fan RPM = 0
+    0x00, 0x83,     # inlet = 131
+    0x00, 0x7A,     # casing = 122
+    0x00, 0x71,     # outlet = 113
+    0x05, 0x87,     # altitude = 1415
+])
+
+Q2_DATA_UNAVAILABLE = bytes([
+    0x00,
+    0x00, 0x7F,
+    0x00, 0x00,
+    0xFF, 0xFF,     # inlet unavailable
+    0x00, 0x7A,
+    0xFF, 0xFF,     # outlet unavailable
+    0xFF, 0xFF,     # altitude unavailable
+])
+
+
+# ---------------------------------------------------------------------------
+# Temperature unit detection
+# ---------------------------------------------------------------------------
+
+
+class TestTempUnitDetection:
+    def _coordinator(self, hass_unit=UnitOfTemperature.CELSIUS):
+        hass = _make_hass(hass_unit)
+        entry = _make_entry()
+        with patch(
+            "custom_components.velit.coordinator.VelitHeaterClient"
+        ):
+            coord = VelitHeaterCoordinator(hass, entry)
+        return coord
+
+    def test_celsius_range_detected(self):
+        coord = self._coordinator()
+        assert coord._detect_temp_unit(16) == UnitOfTemperature.CELSIUS
+        assert coord._detect_temp_unit(24) == UnitOfTemperature.CELSIUS
+        assert coord._detect_temp_unit(30) == UnitOfTemperature.CELSIUS
+
+    def test_fahrenheit_range_detected(self):
+        coord = self._coordinator()
+        assert coord._detect_temp_unit(61) == UnitOfTemperature.FAHRENHEIT
+        assert coord._detect_temp_unit(70) == UnitOfTemperature.FAHRENHEIT
+        assert coord._detect_temp_unit(86) == UnitOfTemperature.FAHRENHEIT
+
+    def test_ambiguous_falls_back_to_ha_celsius(self):
+        coord = self._coordinator(hass_unit=UnitOfTemperature.CELSIUS)
+        assert coord._detect_temp_unit(0) == UnitOfTemperature.CELSIUS
+        assert coord._detect_temp_unit(50) == UnitOfTemperature.CELSIUS
+
+    def test_ambiguous_falls_back_to_ha_fahrenheit(self):
+        coord = self._coordinator(hass_unit=UnitOfTemperature.FAHRENHEIT)
+        assert coord._detect_temp_unit(0) == UnitOfTemperature.FAHRENHEIT
+
+    def test_boundary_values_are_ambiguous(self):
+        # 31 and 60 are outside both named ranges — they fall back to HA system unit.
+        # With a Celsius HA system, both should return Celsius (the fallback), not Fahrenheit.
+        coord = self._coordinator(hass_unit=UnitOfTemperature.CELSIUS)
+        assert coord._detect_temp_unit(31) == UnitOfTemperature.CELSIUS   # fallback
+        assert coord._detect_temp_unit(60) == UnitOfTemperature.CELSIUS   # fallback
+
+    def test_boundary_values_with_fahrenheit_ha_preference(self):
+        # Same ambiguous values with a Fahrenheit HA system should return Fahrenheit.
+        coord = self._coordinator(hass_unit=UnitOfTemperature.FAHRENHEIT)
+        assert coord._detect_temp_unit(31) == UnitOfTemperature.FAHRENHEIT
+        assert coord._detect_temp_unit(60) == UnitOfTemperature.FAHRENHEIT
+
+
+# ---------------------------------------------------------------------------
+# Heater coordinator — parse logic
+# ---------------------------------------------------------------------------
+
+
+class TestVelitHeaterCoordinatorParse:
+    def _make_coord(self, hass_unit=UnitOfTemperature.CELSIUS):
+        hass = _make_hass(hass_unit)
+        entry = _make_entry()
+        with patch("custom_components.velit.coordinator.VelitHeaterClient"):
+            coord = VelitHeaterCoordinator(hass, entry)
+        return coord
+
+    def test_fahrenheit_setpoint_detected_and_converted(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, Q2_DATA)
+        assert coord.temp_unit == UnitOfTemperature.FAHRENHEIT
+        # 70°F → (70-32)/1.8 ≈ 21.1°C
+        assert abs(data["set_temp_c"] - 21.11) < 0.1
+
+    def test_celsius_setpoint_detected(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_C, Q2_DATA)
+        assert coord.temp_unit == UnitOfTemperature.CELSIUS
+        assert data["set_temp_c"] == 24.0
+
+    def test_fault_code_mapped_to_name(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, Q2_DATA)
+        assert data["fault_code"] == 0
+        assert data["fault_name"] == "No Fault"
+
+    def test_fault_code_14_mapped_correctly(self):
+        coord = self._make_coord()
+        q1_fault = bytes([0x0E]) + Q1_DATA_F[1:]  # inject fault code 14
+        data = coord._parse(q1_fault, Q2_DATA)
+        assert data["fault_name"] == "CO Pollution Exceeded"
+
+    def test_machine_state_mapped(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, Q2_DATA)
+        assert data["machine_state"] == 1
+        assert data["machine_state_str"] == "Normal"
+
+    def test_voltage_decoded(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, Q2_DATA)
+        assert data["voltage_v"] == pytest.approx(12.7)
+
+    def test_inlet_temp_decoded_fahrenheit(self):
+        """Hardware-verified: inlet raw 131, in F mode → 131-60=71°F → 21.7°C."""
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, Q2_DATA)
+        assert coord.temp_unit == UnitOfTemperature.FAHRENHEIT
+        # raw 131, offset -60 = 71°F, converted to C ≈ 21.67
+        assert abs(data["inlet_temp_c"] - 21.67) < 0.1
+
+    def test_sensor_unavailable_returns_none(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, Q2_DATA_UNAVAILABLE)
+        assert data["inlet_temp_c"] is None
+        assert data["outlet_temp_c"] is None
+        assert data["altitude"] is None
+
+    def test_gear_and_work_mode(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, Q2_DATA)
+        assert data["current_gear"] == 5
+        assert data["work_mode"] == 2  # thermostat
+
+    def test_fuel_pump_frequency(self):
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_C, Q2_DATA)
+        # Q1_DATA_C has pump_freq byte = 0x05 → 0.5 Hz
+        assert data["fuel_pump_hz"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Heater coordinator — poll raises UpdateFailed on no response
+# ---------------------------------------------------------------------------
+
+
+class TestVelitHeaterCoordinatorPoll:
+    async def _make_coord(self):
+        hass = _make_hass()
+        entry = _make_entry()
+        with patch("custom_components.velit.coordinator.VelitHeaterClient") as mock_cls:
+            coord = VelitHeaterCoordinator(hass, entry)
+            coord._client = mock_cls.return_value
+        return coord
+
+    async def test_raises_on_q1_none(self):
+        coord = await self._make_coord()
+        coord._client.send_command = AsyncMock(return_value=None)
+        with pytest.raises(UpdateFailed):
+            await coord._async_poll()
+
+    async def test_raises_on_q2_none(self):
+        coord = await self._make_coord()
+        q1_response = {"data": Q1_DATA_F, "func": 0x0A}
+        coord._client.send_command = AsyncMock(
+            side_effect=[q1_response, None]
+        )
+        with pytest.raises(UpdateFailed):
+            await coord._async_poll()
+
+    async def test_returns_data_on_success(self):
+        coord = await self._make_coord()
+        q1_response = {"data": Q1_DATA_F, "func": 0x0A}
+        q2_response = {"data": Q2_DATA, "func": 0x0B}
+        coord._client.send_command = AsyncMock(
+            side_effect=[q1_response, q2_response]
+        )
+        data = await coord._async_poll()
+        assert data["fault_code"] == 0
+        assert data["voltage_v"] == pytest.approx(12.7)
+
+
+# ---------------------------------------------------------------------------
+# AC coordinator — basic poll
+# ---------------------------------------------------------------------------
+
+
+class TestVelitACCoordinatorPoll:
+    async def _make_coord(self):
+        hass = _make_hass()
+        entry = _make_entry(device_type="ac")
+        with patch("custom_components.velit.coordinator.VelitACClient") as mock_cls:
+            coord = VelitACCoordinator(hass, entry)
+            coord._client = mock_cls.return_value
+        return coord
+
+    def _mock_responses(self, mode=1, temp=24, fan=3, swing=2):
+        """Build the ordered list of send_command responses for a full AC poll."""
+        return [
+            {"data": bytes([mode]), "func": 0x02},   # mode
+            {"data": bytes([temp]), "func": 0x03},   # temp
+            {"data": bytes([fan]),  "func": 0x04},   # fan
+            {"data": bytes([swing]),"func": 0x10},   # swing
+            None,                                     # inlet (unconfirmed format)
+            None,                                     # fault (unconfirmed format)
+        ]
+
+    async def test_raises_on_mode_none(self):
+        coord = await self._make_coord()
+        coord._client.send_command = AsyncMock(return_value=None)
+        with pytest.raises(UpdateFailed):
+            await coord._async_poll()
+
+    async def test_returns_data_on_success(self):
+        coord = await self._make_coord()
+        coord._client.send_command = AsyncMock(
+            side_effect=self._mock_responses(mode=1, temp=24, fan=3, swing=2)
+        )
+        data = await coord._async_poll()
+        assert data["mode"] == 1
+        assert data["set_temp_c"] == 24.0
+        assert data["fan_speed"] == 3
+        assert data["swing"] == 2
+        assert data["inlet_temp_raw"] is None
+        assert data["fault_raw"] is None
+
+    async def test_unit_detected_celsius(self):
+        coord = await self._make_coord()
+        coord._client.send_command = AsyncMock(
+            side_effect=self._mock_responses(temp=24)
+        )
+        await coord._async_poll()
+        assert coord.temp_unit == UnitOfTemperature.CELSIUS
+
+    async def test_unit_detected_fahrenheit(self):
+        coord = await self._make_coord()
+        coord._client.send_command = AsyncMock(
+            side_effect=self._mock_responses(temp=75)
+        )
+        await coord._async_poll()
+        assert coord.temp_unit == UnitOfTemperature.FAHRENHEIT

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,188 @@
+"""Unit tests for Velit sensor entities.
+
+All coordinator access is mocked — no hardware or BLE required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import UnitOfTemperature
+
+from custom_components.velit.sensor import (
+    VelitACFaultSensorEntity,
+    VelitHeaterSensorEntity,
+    HEATER_SENSORS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_heater_data(**overrides):
+    base = {
+        "fault_code": 0,
+        "fault_name": "No Fault",
+        "work_mode": 1,
+        "current_gear": 3,
+        "set_temp_c": 22.0,
+        "machine_state": 1,
+        "machine_state_str": "Normal",
+        "heater_power_w": 80,
+        "fuel_pump_hz": 0.5,
+        "voltage_v": 12.7,
+        "fan_rpm": 1200,
+        "inlet_temp_c": 21.7,
+        "casing_temp_c": 16.7,
+        "outlet_temp_c": 11.7,
+        "altitude": 1415,
+    }
+    base.update(overrides)
+    return base
+
+
+_UNSET = object()
+
+
+def _sensor_for_key(key: str, data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
+    description = next(d for d in HEATER_SENSORS if d.key == key)
+    coord = MagicMock()
+    coord.data = data if data is not _UNSET else _make_heater_data()
+    coord.temp_unit = temp_unit
+    entry = MagicMock()
+    entry.data = {"address": "AA:BB:CC:DD:EE:FF", "name": "Test"}
+    entity = VelitHeaterSensorEntity.__new__(VelitHeaterSensorEntity)
+    entity.coordinator = coord
+    entity.entity_description = description
+    entity._attr_unique_id = f"test_{key}"
+    entity._attr_device_info = MagicMock()
+    if key == "altitude":
+        entity._attr_native_unit_of_measurement = (
+            "ft" if temp_unit == UnitOfTemperature.FAHRENHEIT else "m"
+        )
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# Heater sensor values
+# ---------------------------------------------------------------------------
+
+
+class TestHeaterSensorValues:
+    def test_inlet_temp(self):
+        entity = _sensor_for_key("inlet_temp")
+        assert entity.native_value == pytest.approx(21.7)
+
+    def test_casing_temp(self):
+        entity = _sensor_for_key("casing_temp")
+        assert entity.native_value == pytest.approx(16.7)
+
+    def test_outlet_temp(self):
+        entity = _sensor_for_key("outlet_temp")
+        assert entity.native_value == pytest.approx(11.7)
+
+    def test_voltage(self):
+        entity = _sensor_for_key("voltage")
+        assert entity.native_value == pytest.approx(12.7)
+
+    def test_fan_rpm(self):
+        entity = _sensor_for_key("fan_rpm")
+        assert entity.native_value == 1200
+
+    def test_altitude(self):
+        entity = _sensor_for_key("altitude")
+        assert entity.native_value == 1415
+
+    def test_fault_no_fault(self):
+        entity = _sensor_for_key("fault_code")
+        assert entity.native_value == "No Fault"
+
+    def test_fault_co_pollution(self):
+        data = _make_heater_data(fault_name="CO Pollution Exceeded")
+        entity = _sensor_for_key("fault_code", data=data)
+        assert entity.native_value == "CO Pollution Exceeded"
+
+    def test_machine_state(self):
+        entity = _sensor_for_key("machine_state")
+        assert entity.native_value == "Normal"
+
+    def test_machine_state_cooling_down(self):
+        data = _make_heater_data(machine_state_str="Cooling Down")
+        entity = _sensor_for_key("machine_state", data=data)
+        assert entity.native_value == "Cooling Down"
+
+
+# ---------------------------------------------------------------------------
+# Unavailable sensor values
+# ---------------------------------------------------------------------------
+
+
+class TestHeaterSensorUnavailable:
+    def test_inlet_temp_none_when_unavailable(self):
+        data = _make_heater_data(inlet_temp_c=None)
+        entity = _sensor_for_key("inlet_temp", data=data)
+        assert entity.native_value is None
+
+    def test_outlet_temp_none_when_unavailable(self):
+        data = _make_heater_data(outlet_temp_c=None)
+        entity = _sensor_for_key("outlet_temp", data=data)
+        assert entity.native_value is None
+
+    def test_altitude_none_when_unavailable(self):
+        data = _make_heater_data(altitude=None)
+        entity = _sensor_for_key("altitude", data=data)
+        assert entity.native_value is None
+
+    def test_all_none_when_coordinator_data_none(self):
+        for description in HEATER_SENSORS:
+            entity = _sensor_for_key(description.key, data=None)
+            assert entity.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# Altitude unit
+# ---------------------------------------------------------------------------
+
+
+class TestAltitudeUnit:
+    def test_altitude_unit_metres_in_celsius_mode(self):
+        entity = _sensor_for_key("altitude", temp_unit=UnitOfTemperature.CELSIUS)
+        assert entity._attr_native_unit_of_measurement == "m"
+
+    def test_altitude_unit_feet_in_fahrenheit_mode(self):
+        entity = _sensor_for_key("altitude", temp_unit=UnitOfTemperature.FAHRENHEIT)
+        assert entity._attr_native_unit_of_measurement == "ft"
+
+
+# ---------------------------------------------------------------------------
+# AC fault sensor
+# ---------------------------------------------------------------------------
+
+
+class TestACFaultSensor:
+    def _make_entity(self, fault_raw=None):
+        coord = MagicMock()
+        coord.data = {"fault_raw": fault_raw, "mode": 1, "set_temp_c": 22.0,
+                      "fan_speed": 3, "swing": 2, "inlet_temp_raw": None}
+        entry = MagicMock()
+        entry.data = {"address": "AA:BB:CC:DD:EE:FF", "name": "Test AC"}
+        entity = VelitACFaultSensorEntity.__new__(VelitACFaultSensorEntity)
+        entity.coordinator = coord
+        entity._attr_unique_id = "test_ac_fault"
+        entity._attr_device_info = MagicMock()
+        return entity
+
+    def test_none_when_no_data(self):
+        entity = self._make_entity(fault_raw=None)
+        assert entity.native_value is None
+
+    def test_raw_bytes_returned_as_hex(self):
+        entity = self._make_entity(fault_raw=bytes([0x00, 0x01]))
+        assert entity.native_value == "0001"
+
+    def test_none_coordinator_data_returns_none(self):
+        entity = self._make_entity()
+        entity.coordinator.data = None
+        assert entity.native_value is None


### PR DESCRIPTION
## Summary

- `coordinator.py`: VelitHeaterCoordinator polls Query 1 (0x0A) + Query 2 (0x0B), parses all fields with hardware-verified sensor offsets; VelitACCoordinator polls mode/temp/fan/swing; both use UpdateFailed on BLE errors, always_update=False
- Temperature unit detection from Q1 setpoint on first connect (16-30 = C, 61-86 = F, else HA system unit) — never sends a value that flips the device LCD unit
- `climate.py`: VelitHeaterClimateEntity (OFF/HEAT, manual/thermostat presets, gear 1-5); VelitACClimateEntity (OFF/COOL/HEAT/FAN_ONLY/DRY, energy_saving/sleep/turbo presets, fan 1-5, swing)
- `sensor.py`: 9 heater sensors (inlet/casing/outlet temp, voltage, fan RPM, altitude, fuel pump freq, heater power, fault, machine state); AC fault sensor stores raw bytes pending format confirmation
- `__init__.py`: async_setup_entry creates coordinator, connects, first refresh, forwards to platforms; async_on_unload handles disconnect
- 81 new tests (133 total)

**Merge after:** feature/config-flow
**Merge before:** feature/heater-state-feedback