### PR TITLE
Switch to bleak_retry_connector for reliable BLE connection

### DIFF
--- a/custom_components/velit/ac_client.py
+++ b/custom_components/velit/ac_client.py
@@ -30,6 +30,10 @@ import time
 
 from bleak import BleakClient, BLEDevice
 from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+
+from homeassistant.components import bluetooth
+from homeassistant.core import HomeAssistant
 
 from .const import (
     AC_COMMAND_INTERVAL_MS,
@@ -150,17 +154,20 @@ class VelitACClient:
 
     def __init__(
         self,
+        hass: HomeAssistant,
         address: str | BLEDevice,
         product_code: int = DEFAULT_PRODUCT_CODE,
     ) -> None:
         """
         Args:
+            hass:         HomeAssistant instance — used to resolve BLEDevice at connect time.
             address:      BLE device address or BLEDevice from discovery.
             product_code: 1-byte product identifier (default 0x01).
         """
-        self._address = address
+        self._hass = hass
+        self._address: str = address.address if isinstance(address, BLEDevice) else address
         self._product_code = product_code
-        self._client: BleakClient | None = None
+        self._client: BleakClientWithServiceCache | None = None
         self._queue: asyncio.Queue[
             tuple[int, bytes, asyncio.Future[dict | None]]
         ] = asyncio.Queue()
@@ -178,13 +185,22 @@ class VelitACClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        client = BleakClient(
+        device = bluetooth.async_ble_device_from_address(
+            self._hass, self._address, connectable=True
+        )
+        if device is None:
+            raise RuntimeError(f"Device {self._address} not found in Bluetooth scanner cache")
+
+        # establish_connection handles transient failures and uses the service cache
+        # to skip GATT re-discovery on reconnect, per HA Bluetooth integration guidelines.
+        client = await establish_connection(
+            BleakClientWithServiceCache,
+            device,
             self._address,
             disconnected_callback=self._on_disconnect,
         )
         self._client = client
         try:
-            await client.connect()
             await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
         except Exception:
             # Disconnect before re-raising so BlueZ releases this connection and
@@ -356,7 +372,7 @@ class VelitACClient:
         elif parsed:
             _LOGGER.debug("Unsolicited notification: func 0x%02X", parsed.get("func"))
 
-    def _on_disconnect(self, _client: BleakClient) -> None:
+    def _on_disconnect(self, _client: BleakClientWithServiceCache) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
         if not self._connected:
             # The disconnect fired during a failed connect() attempt —

--- a/custom_components/velit/ac_client.py
+++ b/custom_components/velit/ac_client.py
@@ -28,7 +28,7 @@ import asyncio
 import logging
 import time
 
-from bleak import BleakClient, BLEDevice
+from bleak import BLEDevice
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -221,7 +221,7 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         super().__init__(hass, entry, name=f"Velit Heater {entry.data['address']}")
-        self._client = VelitHeaterClient(self._address)
+        self._client = VelitHeaterClient(self.hass, self._address)
         self._unit_detected = False
 
     async def _async_poll(self) -> dict:
@@ -318,7 +318,7 @@ class VelitACCoordinator(_VelitBaseCoordinator):
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         super().__init__(hass, entry, name=f"Velit AC {entry.data['address']}")
-        self._client = VelitACClient(self._address)
+        self._client = VelitACClient(self.hass, self._address)
         self._unit_detected = False
 
     async def _async_poll(self) -> dict:

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -27,6 +27,10 @@ import logging
 
 from bleak import BleakClient, BLEDevice
 from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+
+from homeassistant.components import bluetooth
+from homeassistant.core import HomeAssistant
 
 from .const import HEATER_MASTER_ADDR, HEATER_SLAVE_ADDR, UUID_READ_NOTIFY, UUID_WRITE
 
@@ -152,21 +156,24 @@ class VelitHeaterClient:
 
     def __init__(
         self,
+        hass: HomeAssistant,
         address: str | BLEDevice,
         master_addr: bytes = HEATER_MASTER_ADDR,
         slave_addr: bytes = HEATER_SLAVE_ADDR,
     ) -> None:
         """
         Args:
+            hass:        HomeAssistant instance — used to resolve BLEDevice at connect time.
             address:     BLE device address or BLEDevice from discovery.
             master_addr: 4-byte master address (arbitrary — device ignores its value).
             slave_addr:  4-byte slave address (fixed constant on all known Velit heaters;
                          device isolation is provided by the BLE connection, not this field).
         """
-        self._address = address
+        self._hass = hass
+        self._address: str = address.address if isinstance(address, BLEDevice) else address
         self._master_addr = master_addr
         self._slave_addr = slave_addr
-        self._client: BleakClient | None = None
+        self._client: BleakClientWithServiceCache | None = None
         self._queue: asyncio.Queue[
             tuple[int, bytes, asyncio.Future[dict | None]]
         ] = asyncio.Queue()
@@ -182,13 +189,22 @@ class VelitHeaterClient:
 
     async def connect(self) -> None:
         """Connect to the device and subscribe to response notifications."""
-        client = BleakClient(
+        device = bluetooth.async_ble_device_from_address(
+            self._hass, self._address, connectable=True
+        )
+        if device is None:
+            raise RuntimeError(f"Device {self._address} not found in Bluetooth scanner cache")
+
+        # establish_connection handles transient failures and uses the service cache
+        # to skip GATT re-discovery on reconnect, per HA Bluetooth integration guidelines.
+        client = await establish_connection(
+            BleakClientWithServiceCache,
+            device,
             self._address,
             disconnected_callback=self._on_disconnect,
         )
         self._client = client
         try:
-            await client.connect()
             await client.start_notify(UUID_READ_NOTIFY, self._on_notification)
         except Exception:
             # Disconnect before re-raising so BlueZ releases this connection and
@@ -302,7 +318,7 @@ class VelitHeaterClient:
         elif parsed:
             _LOGGER.debug("Unsolicited notification: func 0x%02X", parsed.get("func"))
 
-    def _on_disconnect(self, _client: BleakClient) -> None:
+    def _on_disconnect(self, _client: BleakClientWithServiceCache) -> None:
         """Called by bleak when the connection is lost unexpectedly."""
         if not self._connected:
             # The disconnect fired during a failed connect() attempt —

--- a/custom_components/velit/heater_client.py
+++ b/custom_components/velit/heater_client.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from bleak import BleakClient, BLEDevice
+from bleak import BLEDevice
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 

--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -13,6 +13,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JohnFreeborg/velit-hass/issues",
-  "requirements": [],
+  "requirements": ["bleak-retry-connector"],
   "version": "0.0.1"
 }

--- a/custom_components/velit/switch.py
+++ b/custom_components/velit/switch.py
@@ -18,7 +18,7 @@ import logging
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, UnitOfTime
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback


### PR DESCRIPTION
## Summary

- Replaces direct `BleakClient` usage with `establish_connection()` from `bleak_retry_connector` in both `VelitHeaterClient` and `VelitACClient`
- Uses `bluetooth.async_ble_device_from_address()` to resolve the BLE device from HA's scanner cache at connect time
- Uses `BleakClientWithServiceCache` to skip GATT re-discovery on reconnect
- Removes unused `BleakClient` import and pre-existing unused `UnitOfTime` import (ruff)

## Motivation

Andrew (chicagoandy, issue #14) reported 25 occurrences of "connect() called without bleak-retry-connector" warnings. Root cause: direct `BleakClient` usage bypasses HA's recommended connection layer. This also caused unreliable connections and potentially connected to wrong BLE peripherals.

## Hardware validation

Confirmed on Jeremy's hardware (C8:47:80:5F:C5:EB): no BleakClient warning on clean restart, polls succeeding every 30s, reconnect working correctly.

## Test plan

- [ ] CI passes (hassfest, HACS, tests)
- [ ] Hardware: confirm no BleakClient warning, stable polling, reconnect after disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)