### PR TITLE
Add manufacturer ID bluetooth matcher for devices without VELIT* name

### DIFF
--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -5,7 +5,8 @@
   "bluetooth": [
     {"local_name": "VELIT*", "connectable": true},
     {"local_name": "VLIT*", "connectable": true},
-    {"local_name": "D30*", "connectable": true}
+    {"local_name": "D30*", "connectable": true},
+    {"manufacturer_id": 22618, "connectable": true}
   ],
   "codeowners": ["@JohnFreeborg", "@jeremyroe"],
   "config_flow": true,


### PR DESCRIPTION
## Summary

- Adds `{"manufacturer_id": 22618, "connectable": true}` as an additional bluetooth matcher in `manifest.json`
- Company ID 22618 (0x585A, BEKEN Corp) is present in all known Velit advertisements
- Also extends the manual config flow scan filter with the same manufacturer ID fallback

## Motivation

Andrew (chicagoandy, issue #13) reported Bluetooth discovery not working. His device (`C8:47:80:57:7F:E1`) advertises with its MAC address as the local name rather than a `VELIT*`/`VLIT*`/`D30*` prefix — a firmware variation. The existing name-based matchers never fired.

The manufacturer ID matcher catches all Velit devices regardless of firmware name format. The config flow device-type selector acts as the guard against false positives.

## Test plan

- [ ] CI passes (hassfest, HACS, tests)
- [ ] Andrew confirms discovery works on his device

🤖 Generated with [Claude Code](https://claude.com/claude-code)