### PR TITLE
Disable casing and outlet temp sensors pending encoding verification

### DIFF
--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -2,8 +2,8 @@
 
 Heater sensors (all sourced from coordinator data):
   - Inlet temperature
-  - Casing temperature
-  - Outlet temperature
+  - Casing temperature (disabled by default — encoding unconfirmed)
+  - Outlet temperature (disabled by default — encoding unconfirmed)
   - Supply voltage
   - Fan RPM
   - Altitude
@@ -73,6 +73,8 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        # Encoding unconfirmed — disabled until verified with Velit
+        entity_registry_enabled_default=False,
     ),
     VelitSensorEntityDescription(
         key="outlet_temp",
@@ -81,6 +83,8 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        # Encoding unconfirmed — disabled until verified with Velit
+        entity_registry_enabled_default=False,
     ),
     VelitSensorEntityDescription(
         key="voltage",


### PR DESCRIPTION
## Summary

- Sets `entity_registry_enabled_default=False` on casing and outlet temperature sensor entities
- Sensors remain in the codebase and continue to be parsed — they can be manually enabled by users who want raw data

## Motivation

Live hardware testing showed casing and outlet temps reporting impossible values (below ambient) when the device is in Fahrenheit mode. The temperature encoding formula for these two sensors is unconfirmed — it is unclear whether they always use `raw - 50 = °C` or follow the device display mode like inlet and setpoint do.

Rather than ship wrong values, sensors are hidden by default until the correct formula is confirmed with Velit.

## Test plan

- [ ] CI passes
- [ ] Confirm casing and outlet sensors do not appear by default on a fresh device registration
- [ ] Confirm sensors can be manually enabled via entity registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)