### PR TITLE
Improve config flow: device scan and mobile app conflict guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ you to complete setup.
 
 **Device not discovered automatically**
 - Confirm the device is powered on and within Bluetooth range.
+- Close the Velit mobile app on all nearby phones before running setup — the app holds
+  the Bluetooth connection and will prevent Home Assistant from finding the device.
 - Check that your HA instance has a working Bluetooth adapter (Settings → System → Hardware).
 - Try adding the device manually using its Bluetooth address.
 

--- a/custom_components/velit/config_flow.py
+++ b/custom_components/velit/config_flow.py
@@ -3,7 +3,10 @@
 Two entry paths:
   - Bluetooth discovery: HA detects a Velit advertisement and calls
     async_step_bluetooth automatically.
-  - Manual: user initiates from the UI and enters the BLE address.
+  - Manual: user initiates from the UI; HA scans for visible Velit devices
+    and presents a picker. If none are found the user is prompted to close
+    the Velit mobile app (which holds the BLE connection) and retry, or
+    fall back to entering the address manually.
 
 Both paths converge at async_step_device_type where the user selects
 Heater or AC and assigns a friendly name. Device type cannot be inferred
@@ -18,7 +21,10 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfoBleak,
+    async_discovered_service_info,
+)
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.helpers.selector import (
@@ -36,6 +42,10 @@ from .const import CONF_POLL_INTERVAL, CONF_UNAVAILABLE_ON_FAULT, DEVICE_TYPE_AC
 
 _LOGGER = logging.getLogger(__name__)
 
+# BLE advertisement name prefixes that identify Velit devices, matching the
+# manifest.json bluetooth matchers.
+_VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30")
+
 
 class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the Velit config flow."""
@@ -49,6 +59,8 @@ class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         self._address: str = ""
         self._name: str = ""
+        # Devices visible during the last scan, keyed by BLE address.
+        self._discovered: dict[str, BluetoothServiceInfoBleak] = {}
 
     # ------------------------------------------------------------------
     # Bluetooth discovery path
@@ -91,7 +103,68 @@ class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle manual entry — user provides the BLE device address."""
+        """Scan for visible Velit devices and present a picker.
+
+        If no devices are found the user is shown a menu that lets them
+        retry the scan (after closing the mobile app) or enter an address
+        manually.
+        """
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            await self.async_set_unique_id(address)
+            self._abort_if_unique_id_configured()
+            self._address = address
+            info = self._discovered.get(address)
+            self._name = info.name if info and info.name else address
+            return await self.async_step_device_type()
+
+        self._discovered = {
+            info.address: info
+            for info in async_discovered_service_info(self.hass, connectable=True)
+            if info.name and info.name.startswith(_VELIT_NAME_PREFIXES)
+        }
+
+        if not self._discovered:
+            return await self.async_step_not_found()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ADDRESS): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                SelectOptionDict(
+                                    value=addr,
+                                    label=f"{info.name} ({addr})",
+                                )
+                                for addr, info in self._discovered.items()
+                            ]
+                        )
+                    )
+                }
+            ),
+        )
+
+    async def async_step_not_found(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show the not-found menu with mobile app guidance and retry/manual options."""
+        return self.async_show_menu(
+            step_id="not_found",
+            menu_options=["retry", "manual"],
+        )
+
+    async def async_step_retry(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Re-run the device scan after the user closes the mobile app."""
+        return await self.async_step_user()
+
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manual address entry fallback when BT scan finds no devices."""
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
             await self.async_set_unique_id(address)
@@ -101,7 +174,7 @@ class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
             return await self.async_step_device_type()
 
         return self.async_show_form(
-            step_id="user",
+            step_id="manual",
             data_schema=vol.Schema({vol.Required(CONF_ADDRESS): str}),
         )
 

--- a/custom_components/velit/config_flow.py
+++ b/custom_components/velit/config_flow.py
@@ -46,6 +46,11 @@ _LOGGER = logging.getLogger(__name__)
 # manifest.json bluetooth matchers.
 _VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30")
 
+# BEKEN Corp manufacturer ID (0x585A = 22618), present in all known Velit
+# advertisements. Some firmware versions advertise with the MAC as the local
+# name rather than a VELIT* prefix — manufacturer ID is the reliable fallback.
+_VELIT_MANUFACTURER_ID = 22618
+
 
 class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the Velit config flow."""
@@ -121,7 +126,8 @@ class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered = {
             info.address: info
             for info in async_discovered_service_info(self.hass, connectable=True)
-            if info.name and info.name.startswith(_VELIT_NAME_PREFIXES)
+            if (info.name and info.name.startswith(_VELIT_NAME_PREFIXES))
+            or _VELIT_MANUFACTURER_ID in info.manufacturer_data
         }
 
         if not self._discovered:

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -4,6 +4,21 @@
     "step": {
       "user": {
         "title": "Add Velit Device",
+        "description": "Select your Velit device.",
+        "data": {
+          "address": "Device"
+        }
+      },
+      "not_found": {
+        "title": "No Devices Found",
+        "description": "No Velit devices were found nearby. If the Velit mobile app is open on any nearby phone, close it and tap Try Again.",
+        "menu_options": {
+          "retry": "Try Again",
+          "manual": "Enter Address Manually"
+        }
+      },
+      "manual": {
+        "title": "Add Velit Device",
         "description": "Enter the Bluetooth address of your Velit device.",
         "data": {
           "address": "Bluetooth Address"
@@ -27,8 +42,7 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "This device is already configured",
-      "no_devices_found": "No Velit devices found nearby"
+      "already_configured": "This device is already configured"
     }
   },
   "issues": {

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -4,6 +4,21 @@
     "step": {
       "user": {
         "title": "Add Velit Device",
+        "description": "Select your Velit device.",
+        "data": {
+          "address": "Device"
+        }
+      },
+      "not_found": {
+        "title": "No Devices Found",
+        "description": "No Velit devices were found nearby. If the Velit mobile app is open on any nearby phone, close it and tap Try Again.",
+        "menu_options": {
+          "retry": "Try Again",
+          "manual": "Enter Address Manually"
+        }
+      },
+      "manual": {
+        "title": "Add Velit Device",
         "description": "Enter the Bluetooth address of your Velit device.",
         "data": {
           "address": "Bluetooth Address"
@@ -27,8 +42,7 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "This device is already configured",
-      "no_devices_found": "No Velit devices found nearby"
+      "already_configured": "This device is already configured"
     }
   },
   "issues": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,8 @@ No hardware required — HA test helpers provide mock BLE discovery objects.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
@@ -25,6 +27,8 @@ HEATER_NAME = "VELIT-VB52_FHJ/4/1"
 
 AC_ADDRESS = "AA:BB:CC:DD:EE:02"
 AC_NAME = "VELIT-AC01_XYZ/1/1"
+
+_PATCH_DISCOVERED = "custom_components.velit.config_flow.async_discovered_service_info"
 
 
 def _make_discovery(address: str, name: str) -> BluetoothServiceInfoBleak:
@@ -157,15 +161,18 @@ async def test_bluetooth_two_different_devices(hass: HomeAssistant) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Manual user path
+# Manual user path — device found in scan
 # ---------------------------------------------------------------------------
 
 
-async def test_user_flow_full(hass: HomeAssistant) -> None:
-    """Manual entry → device type + name → entry created."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+async def test_user_flow_device_found_in_scan(hass: HomeAssistant) -> None:
+    """Scan finds device → picker shown → select device → device type → entry created."""
+    discovery = _make_discovery(HEATER_ADDRESS, HEATER_NAME)
+
+    with patch(_PATCH_DISCOVERED, return_value=[discovery]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
@@ -184,11 +191,79 @@ async def test_user_flow_full(hass: HomeAssistant) -> None:
     assert result["data"]["device_type"] == DEVICE_TYPE_HEATER
 
 
+# ---------------------------------------------------------------------------
+# Manual user path — no devices found
+# ---------------------------------------------------------------------------
+
+
+async def test_user_flow_no_devices_then_manual_entry(hass: HomeAssistant) -> None:
+    """Scan finds nothing → not_found menu → manual entry → entry created."""
+    with patch(_PATCH_DISCOVERED, return_value=[]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] == FlowResultType.MENU
+    assert result["step_id"] == "not_found"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "manual"}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_ADDRESS: HEATER_ADDRESS}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "device_type"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"device_type": DEVICE_TYPE_HEATER, CONF_NAME: "Van Heater"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_ADDRESS] == HEATER_ADDRESS
+
+
+async def test_user_flow_retry_then_found(hass: HomeAssistant) -> None:
+    """Scan finds nothing → not_found menu → retry → device appears → entry created."""
+    discovery = _make_discovery(HEATER_ADDRESS, HEATER_NAME)
+
+    with patch(_PATCH_DISCOVERED, side_effect=[[], [discovery]]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == FlowResultType.MENU
+        assert result["step_id"] == "not_found"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"next_step_id": "retry"}
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_ADDRESS: HEATER_ADDRESS}
+    )
+    assert result["step_id"] == "device_type"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"device_type": DEVICE_TYPE_HEATER, CONF_NAME: "Van Heater"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
 async def test_user_flow_duplicate_aborts(hass: HomeAssistant) -> None:
     """Manual entry with an already-configured address aborts."""
-    # Create an existing entry
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    # Create an existing entry via the manual path
+    with patch(_PATCH_DISCOVERED, return_value=[]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "manual"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_ADDRESS: HEATER_ADDRESS}
@@ -198,9 +273,13 @@ async def test_user_flow_duplicate_aborts(hass: HomeAssistant) -> None:
         user_input={"device_type": DEVICE_TYPE_HEATER, CONF_NAME: "Heater"},
     )
 
-    # Second attempt with the same address
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    # Second attempt with the same address should abort
+    with patch(_PATCH_DISCOVERED, return_value=[]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "manual"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_ADDRESS: HEATER_ADDRESS}


### PR DESCRIPTION
## Summary

- Manual config flow path now scans for visible Velit devices on entry and presents a picker
- If no devices found: shows a "not found" step with options to retry or enter address manually — user can close the Velit mobile app and retry without restarting the flow
- Adds troubleshooting note to README: close Velit mobile app before setup

## Motivation

The Velit mobile app holds an exclusive BLE connection, blocking HA from connecting or discovering the device. Previously users had no guidance and no way to retry without restarting the flow entirely.

## Test plan

- [ ] CI passes
- [ ] Config flow: device found path shows picker and proceeds correctly
- [ ] Config flow: no devices found path shows retry/manual options
- [ ] Manual address entry still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)