### PR TITLE
Rename preset modes and inlet temperature sensor

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -94,7 +94,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     """
 
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
-    _attr_preset_modes = ["manual", "thermostat"]
+    _attr_preset_modes = ["Manual", "Thermostat"]
     _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
@@ -149,8 +149,8 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
             return None
         work_mode = self.coordinator.data["work_mode"]
         if work_mode == _HEATER_MODE_THERMOSTAT:
-            return "thermostat"
-        return "manual"
+            return "Thermostat"
+        return "Manual"
 
     @property
     def current_temperature(self) -> float | None:
@@ -219,14 +219,14 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
             # Start in the currently selected preset mode.
             mode_byte = (
                 0x02
-                if self.preset_mode == "thermostat"
+                if self.preset_mode == "Thermostat"
                 else 0x01
             )
             await self.coordinator._client.send_command(0x01, bytes([mode_byte]))
         await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        mode_byte = 0x02 if preset_mode == "thermostat" else 0x01
+        mode_byte = 0x02 if preset_mode == "Thermostat" else 0x01
         await self.coordinator._client.send_command(0x00, bytes([mode_byte]))
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -61,7 +61,7 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
     VelitSensorEntityDescription(
         key="inlet_temp",
         data_key="inlet_temp_c",
-        name="Inlet Temperature",
+        name="Temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -83,7 +83,7 @@
     },
     "sensor": {
       "inlet_temp": {
-        "name": "Inlet Temperature"
+        "name": "Temperature"
       },
       "casing_temp": {
         "name": "Casing Temperature"

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -83,7 +83,7 @@
     },
     "sensor": {
       "inlet_temp": {
-        "name": "Inlet Temperature"
+        "name": "Temperature"
       },
       "casing_temp": {
         "name": "Casing Temperature"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -120,12 +120,12 @@ class TestHeaterClimateState:
 
     def test_preset_manual(self):
         entity, _ = _heater_entity()
-        assert entity.preset_mode == "manual"
+        assert entity.preset_mode == "Manual"
 
     def test_preset_thermostat(self):
         data = {**_make_heater_coord().data, "work_mode": 2}
         entity, _ = _heater_entity(data=data)
-        assert entity.preset_mode == "thermostat"
+        assert entity.preset_mode == "Thermostat"
 
     def test_current_temperature(self):
         entity, _ = _heater_entity()
@@ -206,12 +206,12 @@ class TestHeaterClimateActions:
 
     async def test_set_preset_thermostat(self):
         entity, coord = _heater_entity()
-        await entity.async_set_preset_mode("thermostat")
+        await entity.async_set_preset_mode("Thermostat")
         coord._client.send_command.assert_called_once_with(0x00, bytes([0x02]))
 
     async def test_set_preset_manual(self):
         entity, coord = _heater_entity()
-        await entity.async_set_preset_mode("manual")
+        await entity.async_set_preset_mode("Manual")
         coord._client.send_command.assert_called_once_with(0x00, bytes([0x01]))
 
     async def test_set_temperature_celsius(self):


### PR DESCRIPTION
Renames climate entity preset modes from lowercase "thermostat"/"manual"
to "Thermostat"/"Manual" for consistent display in the HA climate card.
Renames the "Inlet Temperature" sensor to "Temperature" in sensor.py,
strings.json, and translations/en.json.