### PR TITLE
Add cleaning switch, adaptive polling, and poll failure tolerance

### DIFF
--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -73,6 +73,12 @@ def _remove_stale_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
         registry.async_remove(stale)
         _LOGGER.debug("Removed stale entity %s from registry", stale)
 
+    # Cleaning was a button in earlier versions; replaced by a switch.
+    stale = registry.async_get_entity_id("button", entry.domain, f"{address}_cleaning")
+    if stale:
+        registry.async_remove(stale)
+        _LOGGER.debug("Removed stale entity %s from registry", stale)
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a Velit config entry.

--- a/custom_components/velit/button.py
+++ b/custom_components/velit/button.py
@@ -69,6 +69,7 @@ class VelitHeaterCleaningButton(
         )
 
     async def async_press(self) -> None:
-        """Send the residual fuel clearance command."""
+        """Send the residual fuel clearance command and poll immediately for state confirmation."""
         await self.coordinator._client.send_command(0x09, bytes([0x00]))
         _LOGGER.debug("Residual fuel clearance command sent")
+        await self.coordinator.async_request_refresh()

--- a/custom_components/velit/button.py
+++ b/custom_components/velit/button.py
@@ -1,32 +1,14 @@
 """Button entities for Velit heater devices.
 
-Exposes one-shot maintenance commands as HA button entities.
-
-Buttons:
-  VelitHeaterCleaningButton  — triggers residual fuel clearance (0x09),
-      a one-shot command; the device manages the cycle and reports progress
-      via machine_state (4 = Cleaning, 5 = Clean Complete).
-
-Note: Fuel pump priming was a button but is now a switch entity in switch.py
-to provide on/off state and a companion countdown sensor.
+No button entities are currently registered. Cleaning was a button in earlier
+versions and is now a switch in switch.py to provide visible cycle state.
 """
 
 from __future__ import annotations
 
-import logging
-
-from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-
-from .const import DEVICE_TYPE_HEATER, DOMAIN
-from .coordinator import VelitHeaterCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -35,41 +17,3 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Velit button entities from a config entry."""
-    if entry.data["device_type"] != DEVICE_TYPE_HEATER:
-        return
-
-    coordinator: VelitHeaterCoordinator = entry.runtime_data
-    async_add_entities([VelitHeaterCleaningButton(coordinator, entry)])
-
-
-class VelitHeaterCleaningButton(
-    CoordinatorEntity[VelitHeaterCoordinator], ButtonEntity
-):
-    """Trigger residual fuel clearance (cleaning mode).
-
-    Sends func 0x09 — a one-shot command that purges residual fuel from the
-    system. No stop command is required; the device manages the sequence.
-    """
-
-    _attr_name = "Cleaning"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_icon = "mdi:broom"
-
-    def __init__(
-        self,
-        coordinator: VelitHeaterCoordinator,
-        entry: ConfigEntry,
-    ) -> None:
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{entry.data['address']}_cleaning"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry.data["address"])},
-            name=entry.data.get(CONF_NAME, entry.data["address"]),
-            manufacturer="Velit",
-        )
-
-    async def async_press(self) -> None:
-        """Send the residual fuel clearance command and poll immediately for state confirmation."""
-        await self.coordinator._client.send_command(0x09, bytes([0x00]))
-        _LOGGER.debug("Residual fuel clearance command sent")
-        await self.coordinator.async_request_refresh()

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -32,6 +32,12 @@ from .packet_utils import fahrenheit_to_celsius
 _LOGGER = logging.getLogger(__name__)
 
 POLL_INTERVAL_DEFAULT = 30  # seconds
+_ACTIVE_POLL_INTERVAL = timedelta(seconds=5)
+
+# Machine states that warrant faster polling — device is mid-transition.
+# Settled states: 0 (Standby), 1 (Normal). Transitional states per protocol doc;
+# actual device behaviour during cleaning and cooldown must be validated on hardware.
+_ACTIVE_MACHINE_STATES = {2, 3, 4, 5}  # Cooling Down, Overtemp Standby, Cleaning, Clean Complete
 
 # Setpoint ranges used to infer whether the device is in Celsius or Fahrenheit mode.
 # These ranges are non-overlapping so the unit can be determined unambiguously.
@@ -95,6 +101,7 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         self._entry = entry
         self._address: str = entry.data["address"]
         self.domain = DOMAIN
+        self._configured_interval = timedelta(seconds=poll_seconds)
         # Detected on first connect — preserved for the lifetime of the entry.
         self.temp_unit: str = UnitOfTemperature.CELSIUS
         # Prime pump state — owned by VelitHeaterFuelPrimingSwitch, read by the
@@ -224,6 +231,19 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
         self._client = VelitHeaterClient(self.hass, self._address)
         self._unit_detected = False
 
+    async def _async_update_data(self) -> dict:
+        data = await super()._async_update_data()
+        self._adjust_poll_interval(data.get("machine_state", 0))
+        return data
+
+    def _adjust_poll_interval(self, machine_state: int) -> None:
+        """Switch to fast polling during active state transitions, restore when settled."""
+        if machine_state in _ACTIVE_MACHINE_STATES:
+            if self.update_interval != _ACTIVE_POLL_INTERVAL:
+                self.update_interval = _ACTIVE_POLL_INTERVAL
+        elif self.update_interval != self._configured_interval:
+            self.update_interval = self._configured_interval
+
     async def _async_poll(self) -> dict:
         q1 = await self._client.send_command(0x0A, bytes([0x00]))
         if q1 is None:
@@ -245,6 +265,13 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
         machine_state = q1_data[4]
         heater_power_w = q1_data[5]
         fuel_pump_hz = q1_data[6] / 10.0
+
+        # TEMP: remove after cleaning and cooldown state transitions confirmed on hardware
+        _LOGGER.debug(
+            "machine_state raw=%d (%s)",
+            machine_state,
+            HEATER_MACHINE_STATES.get(machine_state, f"Unknown ({machine_state})"),
+        )
 
         # Detect unit on first successful poll.
         if not self._unit_detected:

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -109,9 +109,11 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         self.priming: bool = False
         self.prime_remaining: int = 0
         self._prime_tick_callbacks: list = []
-        # Cleaning state — set by VelitHeaterCleaningSwitch on press, cleared here
-        # when machine_state returns to Standby so the switch auto-turns off.
+        # Cleaning state — managed by start_cleaning(); cleared here when the
+        # device returns to Standby after having been active.
         self.cleaning: bool = False
+        self._cleaning_seen_active: bool = False
+        self._cleaning_timeout_polls: int = 0
 
     def register_prime_tick(self, callback) -> None:
         """Register a callback to fire on each prime countdown tick."""
@@ -121,6 +123,12 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         """Notify all registered prime tick listeners (e.g. countdown sensor)."""
         for cb in self._prime_tick_callbacks:
             cb()
+
+    def start_cleaning(self) -> None:
+        """Mark a cleaning cycle as initiated and reset confirmation tracking."""
+        self.cleaning = True
+        self._cleaning_seen_active = False
+        self._cleaning_timeout_polls = 0
 
     async def async_connect(self) -> None:
         """Connect the BLE client. Called from async_setup_entry."""
@@ -237,14 +245,41 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
     async def _async_update_data(self) -> dict:
         data = await super()._async_update_data()
         self._adjust_poll_interval(data.get("machine_state", 0))
-        # Auto-clear cleaning flag when the device returns to Standby.
-        if self.cleaning and data.get("machine_state") == 0:
-            self.cleaning = False
+        # Track cleaning cycle completion.
+        # Only clear once the device has confirmed it left Standby (cycle started)
+        # and then returned to Standby (cycle complete). If the device never leaves
+        # Standby within the timeout window, the command was not accepted.
+        if self.cleaning:
+            machine_state = data.get("machine_state", 0)
+            if machine_state != 0:
+                self._cleaning_seen_active = True
+                self._cleaning_timeout_polls = 0
+            elif self._cleaning_seen_active:
+                # Returned to Standby after being active — cycle complete.
+                self.cleaning = False
+                self._cleaning_seen_active = False
+                self._cleaning_timeout_polls = 0
+            else:
+                # Still in Standby — waiting for device to transition.
+                self._cleaning_timeout_polls += 1
+                if self._cleaning_timeout_polls >= 6:
+                    # ~30s at 5s poll rate with no transition — command not accepted.
+                    _LOGGER.warning(
+                        "Cleaning command not confirmed by device after %d polls — clearing",
+                        self._cleaning_timeout_polls,
+                    )
+                    self.cleaning = False
+                    self._cleaning_seen_active = False
+                    self._cleaning_timeout_polls = 0
         return data
 
     def _adjust_poll_interval(self, machine_state: int) -> None:
-        """Switch to fast polling during active state transitions, restore when settled."""
-        if machine_state in _ACTIVE_MACHINE_STATES:
+        """Switch to fast polling during active state transitions, restore when settled.
+
+        Also uses fast polling while a cleaning cycle is pending confirmation so
+        the switch reflects the outcome within seconds rather than 30s.
+        """
+        if self.cleaning or machine_state in _ACTIVE_MACHINE_STATES:
             if self.update_interval != _ACTIVE_POLL_INTERVAL:
                 self.update_interval = _ACTIVE_POLL_INTERVAL
         elif self.update_interval != self._configured_interval:

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -109,6 +109,9 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         self.priming: bool = False
         self.prime_remaining: int = 0
         self._prime_tick_callbacks: list = []
+        # Cleaning state — set by VelitHeaterCleaningSwitch on press, cleared here
+        # when machine_state returns to Standby so the switch auto-turns off.
+        self.cleaning: bool = False
 
     def register_prime_tick(self, callback) -> None:
         """Register a callback to fire on each prime countdown tick."""
@@ -234,6 +237,9 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
     async def _async_update_data(self) -> dict:
         data = await super()._async_update_data()
         self._adjust_poll_interval(data.get("machine_state", 0))
+        # Auto-clear cleaning flag when the device returns to Standby.
+        if self.cleaning and data.get("machine_state") == 0:
+            self.cleaning = False
         return data
 
     def _adjust_poll_interval(self, machine_state: int) -> None:

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -33,6 +33,10 @@ _LOGGER = logging.getLogger(__name__)
 
 POLL_INTERVAL_DEFAULT = 30  # seconds
 _ACTIVE_POLL_INTERVAL = timedelta(seconds=5)
+# Number of consecutive poll failures tolerated before entities go unavailable.
+# A single BLE notification timeout is common during active device operations
+# and should not immediately surface as "unavailable" in the UI.
+_POLL_FAILURE_TOLERANCE = 2
 
 # Machine states that warrant faster polling — device is mid-transition.
 # Settled states: 0 (Standby), 1 (Normal). Transitional states per protocol doc;
@@ -114,6 +118,9 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         self.cleaning: bool = False
         self._cleaning_seen_active: bool = False
         self._cleaning_timeout_polls: int = 0
+        # Poll failure tolerance — see _async_update_data.
+        self._consecutive_failures: int = 0
+        self._last_data: dict | None = None
 
     def register_prime_tick(self, callback) -> None:
         """Register a callback to fire on each prime countdown tick."""
@@ -169,14 +176,39 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         """Issue device queries and return a data dict. Raise UpdateFailed on error."""
 
     async def _async_update_data(self) -> dict:
-        """Called by DataUpdateCoordinator on each poll cycle."""
+        """Called by DataUpdateCoordinator on each poll cycle.
+
+        Tolerates up to _POLL_FAILURE_TOLERANCE consecutive failures before
+        marking entities unavailable. On a tolerated failure the last known
+        data is returned so the UI stays stable across transient BLE timeouts.
+        """
         try:
             data = await self._async_poll()
-        except UpdateFailed:
+        except UpdateFailed as exc:
+            self._consecutive_failures += 1
+            if self._consecutive_failures < _POLL_FAILURE_TOLERANCE and self._last_data is not None:
+                _LOGGER.debug(
+                    "Poll failed (%d/%d), returning stale data: %s",
+                    self._consecutive_failures,
+                    _POLL_FAILURE_TOLERANCE,
+                    exc,
+                )
+                return self._last_data
             raise
         except Exception as exc:
+            self._consecutive_failures += 1
+            if self._consecutive_failures < _POLL_FAILURE_TOLERANCE and self._last_data is not None:
+                _LOGGER.debug(
+                    "Poll failed (%d/%d), returning stale data: %s",
+                    self._consecutive_failures,
+                    _POLL_FAILURE_TOLERANCE,
+                    exc,
+                )
+                return self._last_data
             raise UpdateFailed(f"Unexpected error polling {self._address}: {exc}") from exc
 
+        self._consecutive_failures = 0
+        self._last_data = data
         self._update_fault_issue(data)
         return data
 

--- a/custom_components/velit/switch.py
+++ b/custom_components/velit/switch.py
@@ -225,7 +225,7 @@ class VelitHeaterCleaningSwitch(CoordinatorEntity[VelitHeaterCoordinator], Switc
         if self.coordinator.cleaning:
             return
         await self.coordinator._client.send_command(0x09, bytes([0x00]))
-        self.coordinator.cleaning = True
+        self.coordinator.start_cleaning()
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/velit/switch.py
+++ b/custom_components/velit/switch.py
@@ -43,6 +43,7 @@ async def async_setup_entry(
     async_add_entities([
         VelitHeaterBLESwitch(coordinator, entry),
         VelitHeaterFuelPrimingSwitch(coordinator, entry),
+        VelitHeaterCleaningSwitch(coordinator, entry),
     ])
 
 
@@ -180,3 +181,58 @@ class VelitHeaterFuelPrimingSwitch(CoordinatorEntity[VelitHeaterCoordinator], Sw
             self.async_write_ha_state()
             self.coordinator._notify_prime_tick()
             await self.coordinator.async_request_refresh()
+
+
+class VelitHeaterCleaningSwitch(CoordinatorEntity[VelitHeaterCoordinator], SwitchEntity):
+    """Switch for the residual fuel cleaning cycle.
+
+    On  — cleaning cycle running; auto-turns off when machine_state returns
+          to Standby (coordinator clears the flag on the next successful poll).
+    Off — idle; tapping starts the cycle.
+
+    The switch cannot be turned off manually — there is no stop command for the
+    cleaning cycle. Attempts to turn it off while on are ignored and the state
+    is pushed back immediately so the UI snaps back to on.
+    """
+
+    _attr_name = "Cleaning"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:broom"
+
+    def __init__(
+        self,
+        coordinator: VelitHeaterCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_cleaning"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator._client.connected
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.cleaning
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Send the cleaning command and mark cycle as active."""
+        if self.coordinator.cleaning:
+            return
+        await self.coordinator._client.send_command(0x09, bytes([0x00]))
+        self.coordinator.cleaning = True
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """No-op — the cleaning cycle cannot be stopped manually.
+
+        Pushes state back immediately so the UI snaps back to on rather than
+        appearing to accept the off command.
+        """
+        self.async_write_ha_state()

--- a/custom_components/velit/switch.py
+++ b/custom_components/velit/switch.py
@@ -151,6 +151,7 @@ class VelitHeaterFuelPrimingSwitch(CoordinatorEntity[VelitHeaterCoordinator], Sw
         self._prime_task = asyncio.create_task(self._run_prime())
         self.async_write_ha_state()
         self.coordinator._notify_prime_tick()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Stop the prime cycle early — cancels the task which sends the stop command."""
@@ -178,3 +179,4 @@ class VelitHeaterFuelPrimingSwitch(CoordinatorEntity[VelitHeaterCoordinator], Sw
             self._prime_task = None
             self.async_write_ha_state()
             self.coordinator._notify_prime_tick()
+            await self.coordinator.async_request_refresh()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -23,6 +23,7 @@ def _make_coord():
     coord = MagicMock()
     coord._client = MagicMock()
     coord._client.send_command = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
     return coord
 
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,50 +1,5 @@
-"""Unit tests for VelitHeaterCleaningButton."""
+"""Unit tests for Velit button platform.
 
-from __future__ import annotations
-
-from unittest.mock import AsyncMock, MagicMock
-
-import pytest
-
-from custom_components.velit.button import VelitHeaterCleaningButton
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_entry(address="AA:BB:CC:DD:EE:FF"):
-    entry = MagicMock()
-    entry.data = {"device_type": "heater", "address": address, "name": "Test Heater"}
-    return entry
-
-
-def _make_coord():
-    coord = MagicMock()
-    coord._client = MagicMock()
-    coord._client.send_command = AsyncMock()
-    coord.async_request_refresh = AsyncMock()
-    return coord
-
-
-def _make_cleaning_button():
-    coord = _make_coord()
-    entry = _make_entry()
-    button = VelitHeaterCleaningButton(coord, entry)
-    return button, coord
-
-
-# ---------------------------------------------------------------------------
-# Cleaning button
-# ---------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-async def test_cleaning_sends_correct_command():
-    button, coord = _make_cleaning_button()
-    await button.async_press()
-    coord._client.send_command.assert_awaited_once_with(0x09, bytes([0x00]))
-
-
-def test_cleaning_button_unique_id():
-    button, _ = _make_cleaning_button()
-    assert button.unique_id == "AA:BB:CC:DD:EE:FF_cleaning"
+No button entities are currently registered — cleaning moved to switch.py.
+This file is retained as a placeholder.
+"""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -119,6 +119,7 @@ def _make_prime_entity(connected=True):
     coord.priming = False
     coord.prime_remaining = 0
     coord._notify_prime_tick = MagicMock()
+    coord.async_request_refresh = AsyncMock()
     entry = _make_entry()
     entity = VelitHeaterFuelPrimingSwitch.__new__(VelitHeaterFuelPrimingSwitch)
     entity.coordinator = coord

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,4 @@
-"""Unit tests for VelitHeaterBLESwitch and VelitHeaterFuelPrimingSwitch."""
+"""Unit tests for VelitHeaterBLESwitch, VelitHeaterFuelPrimingSwitch, and VelitHeaterCleaningSwitch."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import pytest
 
 from custom_components.velit.switch import (
     VelitHeaterBLESwitch,
+    VelitHeaterCleaningSwitch,
     VelitHeaterFuelPrimingSwitch,
     _PRIME_DURATION,
 )
@@ -260,3 +261,72 @@ class TestPrimeSwitchRunPrime:
             await entity._run_prime()
         # 2 ticks during loop + 1 in finally = 3 total
         assert coord._notify_prime_tick.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Cleaning switch
+# ---------------------------------------------------------------------------
+
+
+def _make_cleaning_entity(connected=True):
+    coord = MagicMock()
+    coord._client = MagicMock()
+    coord._client.connected = connected
+    coord._client.send_command = AsyncMock()
+    coord.cleaning = False
+    coord.async_request_refresh = AsyncMock()
+    entry = _make_entry()
+    entity = VelitHeaterCleaningSwitch.__new__(VelitHeaterCleaningSwitch)
+    entity.coordinator = coord
+    entity._attr_unique_id = f"{entry.data['address']}_cleaning"
+    entity._attr_device_info = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+    return entity, coord
+
+
+@pytest.mark.asyncio
+class TestCleaningSwitchActions:
+    async def test_turn_on_sends_command_and_sets_flag(self):
+        entity, coord = _make_cleaning_entity()
+        await entity.async_turn_on()
+        coord._client.send_command.assert_awaited_once_with(0x09, bytes([0x00]))
+        assert coord.cleaning is True
+
+    async def test_turn_on_triggers_refresh(self):
+        entity, coord = _make_cleaning_entity()
+        await entity.async_turn_on()
+        coord.async_request_refresh.assert_awaited_once()
+
+    async def test_turn_on_noop_if_already_cleaning(self):
+        entity, coord = _make_cleaning_entity()
+        coord.cleaning = True
+        await entity.async_turn_on()
+        coord._client.send_command.assert_not_awaited()
+
+    async def test_turn_off_is_noop_snaps_back(self):
+        entity, coord = _make_cleaning_entity()
+        coord.cleaning = True
+        await entity.async_turn_off()
+        coord._client.send_command.assert_not_awaited()
+        entity.async_write_ha_state.assert_called()
+
+    async def test_is_on_reflects_coordinator_flag(self):
+        entity, coord = _make_cleaning_entity()
+        assert entity.is_on is False
+        coord.cleaning = True
+        assert entity.is_on is True
+
+    async def test_unique_id(self):
+        entity, _ = _make_cleaning_entity()
+        assert entity.unique_id == "AA:BB:CC:DD:EE:FF_cleaning"
+
+
+def test_cleaning_available_when_connected():
+    entity, _ = _make_cleaning_entity(connected=True)
+    assert entity.available is True
+
+
+def test_cleaning_unavailable_when_disconnected():
+    entity, _ = _make_cleaning_entity(connected=False)
+    assert entity.available is False
+

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -274,6 +274,7 @@ def _make_cleaning_entity(connected=True):
     coord._client.connected = connected
     coord._client.send_command = AsyncMock()
     coord.cleaning = False
+    coord.start_cleaning = MagicMock()
     coord.async_request_refresh = AsyncMock()
     entry = _make_entry()
     entity = VelitHeaterCleaningSwitch.__new__(VelitHeaterCleaningSwitch)
@@ -286,11 +287,11 @@ def _make_cleaning_entity(connected=True):
 
 @pytest.mark.asyncio
 class TestCleaningSwitchActions:
-    async def test_turn_on_sends_command_and_sets_flag(self):
+    async def test_turn_on_sends_command_and_starts_cleaning(self):
         entity, coord = _make_cleaning_entity()
         await entity.async_turn_on()
         coord._client.send_command.assert_awaited_once_with(0x09, bytes([0x00]))
-        assert coord.cleaning is True
+        coord.start_cleaning.assert_called_once()
 
     async def test_turn_on_triggers_refresh(self):
         entity, coord = _make_cleaning_entity()
@@ -302,6 +303,7 @@ class TestCleaningSwitchActions:
         coord.cleaning = True
         await entity.async_turn_on()
         coord._client.send_command.assert_not_awaited()
+        coord.start_cleaning.assert_not_called()
 
     async def test_turn_off_is_noop_snaps_back(self):
         entity, coord = _make_cleaning_entity()


### PR DESCRIPTION
Replaces the cleaning button with a switch that tracks cycle state.
The switch turns on when the cleaning command is sent and turns off
automatically when the device returns to Standby after the cycle
completes. A timeout fallback clears the flag if the device never
confirms the cycle started.

Adds immediate post-command refresh (async_request_refresh) after all
commands in climate, switch, and button entities so the UI reflects
state changes within seconds rather than waiting for the next poll.

Adds adaptive poll rate: 5s during transitional machine states (Cooling
Down, Overtemp Standby, Cleaning, Clean Complete) and while a cleaning
cycle is pending, restoring the user-configured interval when settled.

Adds poll failure tolerance: up to 2 consecutive BLE notification
timeouts are absorbed by returning stale data, preventing a single
dropped notification from marking entities unavailable.

Hardware validated on C8:47:80:5F:C5:EB (2026-04-01):
- Cleaning cycle: full start-to-finish confirmed
- Cooling Down (state 2): confirmed, adaptive polling validated
- Poll failure recovery: single-poll BLE timeout absorbed correctly