### PR TITLE
Hide sensors with no confirmed data on known firmware

### DIFF
--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -102,6 +102,9 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="RPM",
         entity_category=EntityCategory.DIAGNOSTIC,
+        # Always reads 0 RPM on known firmware versions while running — disabled
+        # until confirmed populated by Velit
+        entity_registry_enabled_default=False,
     ),
     VelitSensorEntityDescription(
         key="altitude",
@@ -120,6 +123,9 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfFrequency.HERTZ,
         entity_category=EntityCategory.DIAGNOSTIC,
+        # Always reads 0 Hz on known firmware versions — disabled until confirmed
+        # populated by Velit
+        entity_registry_enabled_default=False,
     ),
     VelitSensorEntityDescription(
         key="heater_power",
@@ -129,6 +135,9 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPower.WATT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        # Always reads 0 W on known firmware versions — disabled until confirmed
+        # populated by Velit
+        entity_registry_enabled_default=False,
     ),
     VelitSensorEntityDescription(
         key="fault_code",


### PR DESCRIPTION
## Summary

- Disables `fan_rpm`, `fuel_pump_hz`, and `heater_power` sensor entities by default via `entity_registry_enabled_default=False`
- All three fields read 0 on firmware 3.26, 3.62, and 3.8 across standby and running states — consistent across all tested hardware
- Coordinator continues parsing the values; users can re-enable manually if needed
- Same approach used for casing/outlet temp sensors in #20

## Test plan

- [ ] 196 tests passing locally
- [ ] Confirm hidden sensors do not appear on device page by default after deploying to Yellow
- [ ] Confirm sensors can be manually re-enabled via entity registry