### PR TITLE
Optimistic hvac_mode update on power on/off

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -120,6 +120,11 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
             name=entry.data.get(CONF_NAME, entry.data["address"]),
             manufacturer="Velit",
         )
+        # Optimistic hvac_mode written immediately after a command so the UI
+        # reflects the expected state without waiting for the next poll.
+        # Cleared once the coordinator confirms the new state, or when the
+        # post-command fast poll window expires (command not accepted by device).
+        self._optimistic_hvac_mode: HVACMode | None = None
 
     # ------------------------------------------------------------------
     # State properties — read from coordinator data, never from device
@@ -138,10 +143,20 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     def hvac_mode(self) -> HVACMode | None:
         if self.coordinator.data is None:
             return None
-        state = self.coordinator.data["machine_state"]
-        if state == 0:
-            return HVACMode.OFF
-        return HVACMode.HEAT
+        actual = (
+            HVACMode.OFF
+            if self.coordinator.data["machine_state"] == 0
+            else HVACMode.HEAT
+        )
+        if self._optimistic_hvac_mode is not None:
+            if actual == self._optimistic_hvac_mode:
+                # Device confirmed expected state — clear optimistic override.
+                self._optimistic_hvac_mode = None
+            elif self.coordinator._post_command_fast_polls == 0:
+                # Fast poll window expired without confirmation — command was not
+                # accepted; revert to actual device state.
+                self._optimistic_hvac_mode = None
+        return self._optimistic_hvac_mode if self._optimistic_hvac_mode is not None else actual
 
     @property
     def preset_mode(self) -> str | None:
@@ -223,11 +238,17 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
                 else 0x01
             )
             await self.coordinator._client.send_command(0x01, bytes([mode_byte]))
+        # Write expected state immediately so the UI responds without waiting
+        # for the next poll. Coordinator confirmation or window expiry clears it.
+        self._optimistic_hvac_mode = hvac_mode
+        self.async_write_ha_state()
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         mode_byte = 0x02 if preset_mode == "Thermostat" else 0x01
         await self.coordinator._client.send_command(0x00, bytes([mode_byte]))
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -240,11 +261,13 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         else:
             value = round(temp_c)
         await self.coordinator._client.send_command(0x08, bytes([value]))
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         gear = int(fan_mode)
         await self.coordinator._client.send_command(0x07, bytes([gear]))
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
 

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -121,6 +121,9 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
         # Poll failure tolerance — see _async_update_data.
         self._consecutive_failures: int = 0
         self._last_data: dict | None = None
+        # Fast polling window armed after any command. Holds 5s interval for N
+        # cycles so state transitions are caught quickly without waiting 30s.
+        self._post_command_fast_polls: int = 0
 
     def register_prime_tick(self, callback) -> None:
         """Register a callback to fire on each prime countdown tick."""
@@ -308,12 +311,15 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
     def _adjust_poll_interval(self, machine_state: int) -> None:
         """Switch to fast polling during active state transitions, restore when settled.
 
-        Also uses fast polling while a cleaning cycle is pending confirmation so
-        the switch reflects the outcome within seconds rather than 30s.
+        Also uses fast polling while a cleaning cycle is pending confirmation or
+        while the post-command window is active, so state changes after any
+        command are caught within seconds rather than 30s.
         """
-        if self.cleaning or machine_state in _ACTIVE_MACHINE_STATES:
+        if self.cleaning or machine_state in _ACTIVE_MACHINE_STATES or self._post_command_fast_polls > 0:
             if self.update_interval != _ACTIVE_POLL_INTERVAL:
                 self.update_interval = _ACTIVE_POLL_INTERVAL
+            if self._post_command_fast_polls > 0:
+                self._post_command_fast_polls -= 1
         elif self.update_interval != self._configured_interval:
             self.update_interval = self._configured_interval
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -59,6 +59,7 @@ def _make_heater_coord(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
     coord.async_request_refresh = AsyncMock()
     coord._client = MagicMock()
     coord._client.send_command = AsyncMock()
+    coord._post_command_fast_polls = 0
     return coord
 
 
@@ -88,6 +89,8 @@ def _heater_entity(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS, options=Non
     entity._attr_unique_id = "test_climate"
     entity._attr_name = "Test Heater"
     entity._attr_device_info = MagicMock()
+    entity._optimistic_hvac_mode = None
+    entity.async_write_ha_state = MagicMock()
     return entity, coord
 
 


### PR DESCRIPTION
## Summary

- Writes expected `hvac_mode` to HA state immediately after a power on/off command rather than waiting for the next coordinator poll
- Optimistic state is cleared as soon as the coordinator confirms the actual device state matches, or when the fast-poll window expires
- Sets `_post_command_fast_polls=6` on all four heater actions (on, off, preset, temperature, fan) so the coordinator polls at 5s intervals for ~30s after any command
- Addresses issue #24 (30s UI latency on mode changes)

## Notes

- Tests for the optimistic logic itself are not yet written — this PR is intentionally narrow; test coverage to follow
- `_post_command_fast_polls` counter is decremented on each fast-poll cycle in `_adjust_poll_interval`

## Test plan

- [ ] Deploy to Yellow, confirm mode change reflects in UI within one poll cycle (~5s) rather than ~30s
- [ ] Confirm state reverts correctly if device does not transition as expected
- [ ] 196 tests passing locally