### PR TITLE
Add optimistic preset mode update on manual/thermostat switch

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -125,6 +125,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         # Cleared once the coordinator confirms the new state, or when the
         # post-command fast poll window expires (command not accepted by device).
         self._optimistic_hvac_mode: HVACMode | None = None
+        self._optimistic_preset_mode: str | None = None
 
     # ------------------------------------------------------------------
     # State properties — read from coordinator data, never from device
@@ -163,9 +164,13 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         if self.coordinator.data is None:
             return None
         work_mode = self.coordinator.data["work_mode"]
-        if work_mode == _HEATER_MODE_THERMOSTAT:
-            return "Thermostat"
-        return "Manual"
+        actual = "Thermostat" if work_mode == _HEATER_MODE_THERMOSTAT else "Manual"
+        if self._optimistic_preset_mode is not None:
+            if actual == self._optimistic_preset_mode:
+                self._optimistic_preset_mode = None
+            elif self.coordinator._post_command_fast_polls == 0:
+                self._optimistic_preset_mode = None
+        return self._optimistic_preset_mode if self._optimistic_preset_mode is not None else actual
 
     @property
     def current_temperature(self) -> float | None:
@@ -248,6 +253,8 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         mode_byte = 0x02 if preset_mode == "Thermostat" else 0x01
         await self.coordinator._client.send_command(0x00, bytes([mode_byte]))
+        self._optimistic_preset_mode = preset_mode
+        self.async_write_ha_state()
         self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -90,6 +90,7 @@ def _heater_entity(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS, options=Non
     entity._attr_name = "Test Heater"
     entity._attr_device_info = MagicMock()
     entity._optimistic_hvac_mode = None
+    entity._optimistic_preset_mode = None
     entity.async_write_ha_state = MagicMock()
     return entity, coord
 


### PR DESCRIPTION
## Summary

- Writes the expected preset mode to HA state immediately after a manual/thermostat command, so the UI reflects the change without waiting for the next poll
- Mirrors the existing optimistic `hvac_mode` pattern from PR #28 — same confirmation and expiry logic
- Fast poll window (`_post_command_fast_polls = 6`) already fires after the command; optimistic state is cleared once the coordinator confirms or the window expires

## Test plan

- [ ] 196 tests passing locally
- [ ] Toggle Manual ↔ Thermostat — UI should update immediately
- [ ] Confirm coordinator clears optimistic state after fast poll confirms