### PR TITLE
Remove unconfirmed and unpopulated heater sensors

### DIFF
--- a/custom_components/velit/__init__.py
+++ b/custom_components/velit/__init__.py
@@ -79,6 +79,13 @@ def _remove_stale_entities(hass: HomeAssistant, entry: ConfigEntry) -> None:
         registry.async_remove(stale)
         _LOGGER.debug("Removed stale entity %s from registry", stale)
 
+    # Sensors removed — encoding unconfirmed or unpopulated on known firmware versions.
+    for key in ("casing_temp", "outlet_temp", "voltage", "fan_rpm", "fuel_pump_freq", "heater_power"):
+        stale = registry.async_get_entity_id("sensor", entry.domain, f"{address}_{key}")
+        if stale:
+            registry.async_remove(stale)
+            _LOGGER.debug("Removed stale entity %s from registry", stale)
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a Velit config entry.

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -2,13 +2,7 @@
 
 Heater sensors (all sourced from coordinator data):
   - Inlet temperature
-  - Casing temperature (disabled by default — encoding unconfirmed)
-  - Outlet temperature (disabled by default — encoding unconfirmed)
-  - Supply voltage
-  - Fan RPM
   - Altitude
-  - Fuel pump frequency (Hz)
-  - Heater power (W)
   - Fault code (human-readable string)
   - Machine state (human-readable string)
 
@@ -33,9 +27,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
-    UnitOfElectricPotential,
-    UnitOfFrequency,
-    UnitOfPower,
     UnitOfTemperature,
     UnitOfTime,
 )
@@ -67,49 +58,6 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     VelitSensorEntityDescription(
-        key="casing_temp",
-        data_key="casing_temp_c",
-        name="Casing Temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        # Encoding unconfirmed — disabled until verified with Velit
-        entity_registry_enabled_default=False,
-    ),
-    VelitSensorEntityDescription(
-        key="outlet_temp",
-        data_key="outlet_temp_c",
-        name="Outlet Temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        # Encoding unconfirmed — disabled until verified with Velit
-        entity_registry_enabled_default=False,
-    ),
-    VelitSensorEntityDescription(
-        key="voltage",
-        data_key="voltage_v",
-        name="Supply Voltage",
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        # Disabled by default — reads 0V on some firmware versions even while running.
-        # Enable manually if the sensor shows a live value on your device.
-        entity_registry_enabled_default=False,
-    ),
-    VelitSensorEntityDescription(
-        key="fan_rpm",
-        data_key="fan_rpm",
-        name="Fan Speed",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement="RPM",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        # Always reads 0 RPM on known firmware versions while running — disabled
-        # until confirmed populated by Velit
-        entity_registry_enabled_default=False,
-    ),
-    VelitSensorEntityDescription(
         key="altitude",
         data_key="altitude",
         name="Altitude",
@@ -117,30 +65,6 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
         # Unit depends on the device's active temperature unit (metric vs imperial).
         # Set dynamically in VelitHeaterSensorEntity based on coordinator.temp_unit.
         entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    VelitSensorEntityDescription(
-        key="fuel_pump_freq",
-        data_key="fuel_pump_hz",
-        name="Fuel Pump Frequency",
-        device_class=SensorDeviceClass.FREQUENCY,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfFrequency.HERTZ,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        # Always reads 0 Hz on known firmware versions — disabled until confirmed
-        # populated by Velit
-        entity_registry_enabled_default=False,
-    ),
-    VelitSensorEntityDescription(
-        key="heater_power",
-        data_key="heater_power_w",
-        name="Heater Power",
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        # Always reads 0 W on known firmware versions — disabled until confirmed
-        # populated by Velit
-        entity_registry_enabled_default=False,
     ),
     VelitSensorEntityDescription(
         key="fault_code",

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -85,26 +85,8 @@
       "inlet_temp": {
         "name": "Temperature"
       },
-      "casing_temp": {
-        "name": "Casing Temperature"
-      },
-      "outlet_temp": {
-        "name": "Outlet Temperature"
-      },
-      "voltage": {
-        "name": "Supply Voltage"
-      },
-      "fan_rpm": {
-        "name": "Fan Speed"
-      },
       "altitude": {
         "name": "Altitude"
-      },
-      "fuel_pump_freq": {
-        "name": "Fuel Pump Frequency"
-      },
-      "heater_power": {
-        "name": "Heater Power"
       },
       "fault_code": {
         "name": "Fault"

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -85,26 +85,8 @@
       "inlet_temp": {
         "name": "Temperature"
       },
-      "casing_temp": {
-        "name": "Casing Temperature"
-      },
-      "outlet_temp": {
-        "name": "Outlet Temperature"
-      },
-      "voltage": {
-        "name": "Supply Voltage"
-      },
-      "fan_rpm": {
-        "name": "Fan Speed"
-      },
       "altitude": {
         "name": "Altitude"
-      },
-      "fuel_pump_freq": {
-        "name": "Fuel Pump Frequency"
-      },
-      "heater_power": {
-        "name": "Heater Power"
       },
       "fault_code": {
         "name": "Fault"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -30,13 +30,7 @@ def _make_heater_data(**overrides):
         "set_temp_c": 22.0,
         "machine_state": 1,
         "machine_state_str": "Normal",
-        "heater_power_w": 80,
-        "fuel_pump_hz": 0.5,
-        "voltage_v": 12.7,
-        "fan_rpm": 1200,
         "inlet_temp_c": 21.7,
-        "casing_temp_c": 16.7,
-        "outlet_temp_c": 11.7,
         "altitude": 1415,
     }
     base.update(overrides)
@@ -75,22 +69,6 @@ class TestHeaterSensorValues:
         entity = _sensor_for_key("inlet_temp")
         assert entity.native_value == pytest.approx(21.7)
 
-    def test_casing_temp(self):
-        entity = _sensor_for_key("casing_temp")
-        assert entity.native_value == pytest.approx(16.7)
-
-    def test_outlet_temp(self):
-        entity = _sensor_for_key("outlet_temp")
-        assert entity.native_value == pytest.approx(11.7)
-
-    def test_voltage(self):
-        entity = _sensor_for_key("voltage")
-        assert entity.native_value == pytest.approx(12.7)
-
-    def test_fan_rpm(self):
-        entity = _sensor_for_key("fan_rpm")
-        assert entity.native_value == 1200
-
     def test_altitude(self):
         entity = _sensor_for_key("altitude")
         assert entity.native_value == 1415
@@ -123,11 +101,6 @@ class TestHeaterSensorUnavailable:
     def test_inlet_temp_none_when_unavailable(self):
         data = _make_heater_data(inlet_temp_c=None)
         entity = _sensor_for_key("inlet_temp", data=data)
-        assert entity.native_value is None
-
-    def test_outlet_temp_none_when_unavailable(self):
-        data = _make_heater_data(outlet_temp_c=None)
-        entity = _sensor_for_key("outlet_temp", data=data)
         assert entity.native_value is None
 
     def test_altitude_none_when_unavailable(self):


### PR DESCRIPTION
## Summary

- Removes six heater sensor entities that are not surfaced in the Velit mobile app and show unreliable or zero values on all tested firmware versions (3.26, 3.62, 3.8):
  - Casing Temperature — encoding unconfirmed
  - Outlet Temperature — encoding unconfirmed
  - Supply Voltage — reads 0V on firmware 3.26 even while running
  - Fan Speed (RPM) — always 0 on all tested firmware while running
  - Fuel Pump Frequency — always 0 on all tested firmware
  - Heater Power — always 0 on all tested firmware
- Coordinator continues parsing these fields from the BLE response — no protocol changes
- Stale entity cleanup added to `_remove_stale_entities()` so existing installs automatically remove orphaned entities on next HA restart
- Inlet temperature, altitude, fault, and machine state sensors are unaffected

## Test plan
- [ ] 191 tests passing locally
- [ ] Verify device page shows only: Temperature, Altitude, Fault, Machine State, Prime Countdown
- [ ] Confirm orphaned entities are removed cleanly on an existing install after update