### PR TITLE
Add FAN_ONLY ventilation mode, rename Thermostat preset to Auto, remove fan mode

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -83,19 +83,17 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     """Climate entity for a Velit heater (protocol V1.02).
 
     HVAC modes:
-      OFF   — heater is shut down
-      HEAT  — heater running (manual or thermostat preset)
+      OFF      — heater is shut down
+      HEAT     — heater running (Auto or Manual preset)
+      FAN_ONLY — ventilation only, no combustion (protocol 0x03/0x04)
 
     Presets (only meaningful in HEAT mode):
-      manual      — fixed gear, no thermostat
-      thermostat  — thermostat controls output
-
-    Fan modes: gear levels 1–5 (only meaningful in manual mode).
+      Auto    — device controls burner level automatically to hit setpoint
+      Manual  — fixed burner level (gear), thermostat inactive
     """
 
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
-    _attr_preset_modes = ["Manual", "Thermostat"]
-    _attr_fan_modes = FAN_MODES
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.FAN_ONLY]
+    _attr_preset_modes = ["Auto", "Manual"]
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
     _attr_min_temp = float(HEATER_MIN_TEMP_C)
@@ -103,7 +101,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.PRESET_MODE
-        | ClimateEntityFeature.FAN_MODE
     )
 
     def __init__(
@@ -126,6 +123,9 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         # post-command fast poll window expires (command not accepted by device).
         self._optimistic_hvac_mode: HVACMode | None = None
         self._optimistic_preset_mode: str | None = None
+        # Ventilation state is tracked here because the device does not report
+        # it in Q1 — the protocol has no ventilation machine_state value.
+        self._ventilating: bool = False
 
     # ------------------------------------------------------------------
     # State properties — read from coordinator data, never from device
@@ -144,11 +144,12 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     def hvac_mode(self) -> HVACMode | None:
         if self.coordinator.data is None:
             return None
-        actual = (
-            HVACMode.OFF
-            if self.coordinator.data["machine_state"] == 0
-            else HVACMode.HEAT
-        )
+        if self._ventilating:
+            actual = HVACMode.FAN_ONLY
+        elif self.coordinator.data["machine_state"] == 0:
+            actual = HVACMode.OFF
+        else:
+            actual = HVACMode.HEAT
         if self._optimistic_hvac_mode is not None:
             if actual == self._optimistic_hvac_mode:
                 # Device confirmed expected state — clear optimistic override.
@@ -161,10 +162,11 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
 
     @property
     def preset_mode(self) -> str | None:
-        if self.coordinator.data is None:
+        # Presets only apply in HEAT mode — hide selector in FAN_ONLY and OFF.
+        if self.coordinator.data is None or self._ventilating:
             return None
         work_mode = self.coordinator.data["work_mode"]
-        actual = "Thermostat" if work_mode == _HEATER_MODE_THERMOSTAT else "Manual"
+        actual = "Auto" if work_mode == _HEATER_MODE_THERMOSTAT else "Manual"
         if self._optimistic_preset_mode is not None:
             if actual == self._optimistic_preset_mode:
                 self._optimistic_preset_mode = None
@@ -185,12 +187,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         return self.coordinator.data.get("set_temp_c")
 
     @property
-    def fan_mode(self) -> str | None:
-        if self.coordinator.data is None:
-            return None
-        return str(self.coordinator.data["current_gear"])
-
-    @property
     def hvac_action(self) -> HVACAction | None:
         """Current action shown on the climate card.
 
@@ -199,6 +195,8 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         """
         if self.coordinator.data is None:
             return None
+        if self._ventilating:
+            return HVACAction.FAN
         # Any active fault — device is not operational.
         if self.coordinator.data["fault_code"] != 0:
             return HVACAction.OFF
@@ -235,14 +233,18 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator._client.send_command(0x02, bytes([0x00]))
+            self._ventilating = False
         elif hvac_mode == HVACMode.HEAT:
-            # Start in the currently selected preset mode.
-            mode_byte = (
-                0x02
-                if self.preset_mode == "Thermostat"
-                else 0x01
-            )
+            if self._ventilating:
+                # Stop ventilation before starting heat. Firmware behaviour on
+                # direct FAN_ONLY → HEAT transition is untested — see TODOS.
+                await self.coordinator._client.send_command(0x04, bytes([0x00]))
+                self._ventilating = False
+            mode_byte = 0x02 if self.preset_mode == "Auto" else 0x01
             await self.coordinator._client.send_command(0x01, bytes([mode_byte]))
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            await self.coordinator._client.send_command(0x03, bytes([0x00]))
+            self._ventilating = True
         # Write expected state immediately so the UI responds without waiting
         # for the next poll. Coordinator confirmation or window expiry clears it.
         self._optimistic_hvac_mode = hvac_mode
@@ -251,7 +253,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        mode_byte = 0x02 if preset_mode == "Thermostat" else 0x01
+        mode_byte = 0x02 if preset_mode == "Auto" else 0x01
         await self.coordinator._client.send_command(0x00, bytes([mode_byte]))
         self._optimistic_preset_mode = preset_mode
         self.async_write_ha_state()
@@ -271,11 +273,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
-    async def async_set_fan_mode(self, fan_mode: str) -> None:
-        gear = int(fan_mode)
-        await self.coordinator._client.send_command(0x07, bytes([gear]))
-        self.coordinator._post_command_fast_polls = 6
-        await self.coordinator.async_request_refresh()
 
 
 class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -91,6 +91,7 @@ def _heater_entity(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS, options=Non
     entity._attr_device_info = MagicMock()
     entity._optimistic_hvac_mode = None
     entity._optimistic_preset_mode = None
+    entity._ventilating = False
     entity.async_write_ha_state = MagicMock()
     return entity, coord
 
@@ -126,10 +127,10 @@ class TestHeaterClimateState:
         entity, _ = _heater_entity()
         assert entity.preset_mode == "Manual"
 
-    def test_preset_thermostat(self):
+    def test_preset_auto(self):
         data = {**_make_heater_coord().data, "work_mode": 2}
         entity, _ = _heater_entity(data=data)
-        assert entity.preset_mode == "Thermostat"
+        assert entity.preset_mode == "Auto"
 
     def test_current_temperature(self):
         entity, _ = _heater_entity()
@@ -139,9 +140,20 @@ class TestHeaterClimateState:
         entity, _ = _heater_entity()
         assert entity.target_temperature == pytest.approx(22.0)
 
-    def test_fan_mode(self):
+    def test_hvac_mode_fan_only_when_ventilating(self):
         entity, _ = _heater_entity()
-        assert entity.fan_mode == "3"
+        entity._ventilating = True
+        assert entity.hvac_mode == HVACMode.FAN_ONLY
+
+    def test_preset_none_when_ventilating(self):
+        entity, _ = _heater_entity()
+        entity._ventilating = True
+        assert entity.preset_mode is None
+
+    def test_hvac_action_fan_when_ventilating(self):
+        entity, _ = _heater_entity()
+        entity._ventilating = True
+        assert entity.hvac_action == HVACAction.FAN
 
     def test_hvac_action_heating_when_normal(self):
         data = {**_make_heater_coord().data, "machine_state": 1, "fault_code": 0}
@@ -182,7 +194,6 @@ class TestHeaterClimateState:
         assert entity.hvac_mode is None
         assert entity.current_temperature is None
         assert entity.target_temperature is None
-        assert entity.fan_mode is None
 
 
 # ---------------------------------------------------------------------------
@@ -202,15 +213,36 @@ class TestHeaterClimateActions:
         await entity.async_set_hvac_mode(HVACMode.HEAT)
         coord._client.send_command.assert_called_once_with(0x01, bytes([0x01]))
 
-    async def test_set_hvac_heat_thermostat(self):
+    async def test_set_hvac_heat_auto(self):
         data = {**_make_heater_coord().data, "work_mode": 2}
         entity, coord = _heater_entity(data=data)
         await entity.async_set_hvac_mode(HVACMode.HEAT)
         coord._client.send_command.assert_called_once_with(0x01, bytes([0x02]))
 
-    async def test_set_preset_thermostat(self):
+    async def test_set_hvac_fan_only(self):
         entity, coord = _heater_entity()
-        await entity.async_set_preset_mode("Thermostat")
+        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
+        coord._client.send_command.assert_called_once_with(0x03, bytes([0x00]))
+        assert entity._ventilating is True
+
+    async def test_set_hvac_off_clears_ventilating(self):
+        entity, coord = _heater_entity()
+        entity._ventilating = True
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+        assert entity._ventilating is False
+
+    async def test_set_hvac_heat_from_fan_only_stops_ventilation_first(self):
+        entity, coord = _heater_entity()
+        entity._ventilating = True
+        await entity.async_set_hvac_mode(HVACMode.HEAT)
+        calls = coord._client.send_command.call_args_list
+        assert calls[0] == ((0x04, bytes([0x00])),)
+        assert calls[1][0][0] == 0x01
+        assert entity._ventilating is False
+
+    async def test_set_preset_auto(self):
+        entity, coord = _heater_entity()
+        await entity.async_set_preset_mode("Auto")
         coord._client.send_command.assert_called_once_with(0x00, bytes([0x02]))
 
     async def test_set_preset_manual(self):
@@ -230,14 +262,9 @@ class TestHeaterClimateActions:
         await entity.async_set_temperature(temperature=24.0)
         coord._client.send_command.assert_called_once_with(0x08, bytes([75]))
 
-    async def test_set_fan_mode(self):
-        entity, coord = _heater_entity()
-        await entity.async_set_fan_mode("5")
-        coord._client.send_command.assert_called_once_with(0x07, bytes([5]))
-
     async def test_refresh_called_after_each_action(self):
         entity, coord = _heater_entity()
-        await entity.async_set_fan_mode("2")
+        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
         coord.async_request_refresh.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

- Adds `FAN_ONLY` as a third HVAC mode, wired to the ventilation commands (`0x03` start / `0x04` stop). The fan icon appears in the climate card mode row alongside Heat and Off.
- Renames the `Thermostat` preset to `Auto` — more accurate description of what the mode does (device controls burner level automatically to hit setpoint).
- Removes `FAN_MODE` (gear 1–5) from the climate entity. Gear is a burner output level controlling fuel pump, combustion, and fan together — not an independent fan speed control. Discrete fan control is not exposed by the protocol.
- Preset selector is hidden automatically when in `FAN_ONLY` or `OFF` mode — only appears within `HEAT` mode where it is meaningful.
- Ventilation state is tracked on the entity (`_ventilating`) since the device does not report a ventilation machine state in Q1 responses.
- Switching directly from `FAN_ONLY` to `HEAT` sends `0x04` (stop ventilation) before `0x01` (startup) — firmware behaviour on this transition is not yet confirmed on hardware, see open test item in TODOS.

## Test plan
- [ ] 200 tests passing locally
- [ ] Fan icon selectable in HA climate card — device enters ventilation mode
- [ ] Off icon stops ventilation correctly
- [ ] Heat from FAN_ONLY transitions cleanly (stop ventilation → startup)
- [ ] Auto / Manual preset visible only in Heat mode
- [ ] Preset rename (Auto) reflects correctly in UI and automations