### PR TITLE
Fix firmware query order and document ffe0 false positive risk

### DIFF
--- a/tools/discover.py
+++ b/tools/discover.py
@@ -104,6 +104,9 @@ def _is_velit(device: BLEDevice, adv: AdvertisementData) -> bool:
         return True
     if _VELIT_MANUFACTURER_ID in adv.manufacturer_data:
         return True
+    # 0000ffe0 is a generic UART-over-BLE UUID and may appear on non-Velit
+    # devices (e.g. SOK batteries). This filter intentionally casts wide —
+    # the config flow protocol handshake is the guard against false positives.
     return _VELIT_SERVICE_UUID in (adv.service_uuids or [])
 
 
@@ -240,19 +243,20 @@ async def probe(address: str) -> None:
                 props = ", ".join(char.properties)
                 print(f"    Char: {char.uuid}  [{props}]")
 
+        # Subscribe before sending any commands so responses are not missed,
+        # including the firmware version JSON response sent immediately below.
+        await client.start_notify(_UUID_READ_NOTIFY, on_notify)
+        print(f"\nSubscribed to notifications on {_UUID_READ_NOTIFY}")
+
         # Attempt firmware version query via JSON (AC OTA protocol).
+        # Response (if any) will arrive as a notification on ffe1.
         print("\nQuerying firmware version (JSON command)...")
         try:
             info_cmd = json.dumps({"cmd": "info"}).encode()
             await client.write_gatt_char(_UUID_WRITE, info_cmd, response=False)
             await asyncio.sleep(1.0)
-            print("  (any JSON response will appear as a notification above)")
         except Exception as exc:
             print(f"  firmware query error: {exc}")
-
-        # Subscribe to notifications.
-        await client.start_notify(_UUID_READ_NOTIFY, on_notify)
-        print(f"\nSubscribed to notifications on {_UUID_READ_NOTIFY}")
 
         # --- Heater probe ---
         heater_notification_start = len(notifications)


### PR DESCRIPTION
## Summary

- Move `start_notify` to before the `{"cmd":"info"}` JSON write so the firmware version response is not silently dropped
- Add a comment on `_is_velit()` noting that `0000ffe0` is a generic UART-over-BLE UUID, false positives (e.g. SOK batteries) are expected, and the config flow protocol handshake is the guard

## Context

Found during Robot's first successful AC probe run against a Velit 2000R. The firmware query fired before the notification subscription was active, meaning any JSON response from the device was lost. The SOK battery false positive was also observed in that same run.

## Test plan

- [ ] Robot reruns updated script against 2000R — firmware version notification appears in output
- [ ] Heater probe output unchanged