### PR TITLE
Add Velit AC unit support (BLE discovery, climate entity, sensors, tests)

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -308,6 +308,8 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
         | ClimateEntityFeature.PRESET_MODE
         | ClimateEntityFeature.FAN_MODE
         | ClimateEntityFeature.SWING_MODE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
     )
 
     # Map from AC protocol mode codes to HA HVACMode.
@@ -479,3 +481,7 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
         await self.coordinator._client.send_command(0x10, bytes([value]))
         self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self) -> None:
+        """Power on and restore the last active HVAC mode."""
+        await self.async_set_hvac_mode(self._last_hvac_mode)

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -348,9 +348,10 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
     def hvac_mode(self) -> HVACMode | None:
         if self.coordinator.data is None:
             return None
-        mode_code = self.coordinator.data["mode"]
-        if mode_code == 0:
+        # Power state (func 0x01): 0x01 = off, 0x02 = on.
+        if self.coordinator.data.get("power") == 0x01:
             return HVACMode.OFF
+        mode_code = self.coordinator.data["mode"]
         # Preset codes (4, 5, 6) don't map to an HVACMode directly — return
         # the last known base mode so the UI doesn't flip to an unexpected state.
         if mode_code in self._PRESET_CODES:
@@ -366,6 +367,12 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
             return None
         mode_code = self.coordinator.data["mode"]
         return self._PRESET_CODES.get(mode_code, AC_PRESET_NONE)
+
+    @property
+    def current_temperature(self) -> float | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("inlet_temp_c")
 
     @property
     def target_temperature(self) -> float | None:

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -343,6 +343,9 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
         # Tracks the last non-preset HVAC mode so we can restore it when
         # clearing a preset (protocol requires resending the base mode code).
         self._last_hvac_mode: HVACMode = HVACMode.COOL
+        # Optimistic state — same pattern as VelitHeaterClimateEntity.
+        self._optimistic_hvac_mode: HVACMode | None = None
+        self._optimistic_preset_mode: str | None = None
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -350,23 +353,37 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
             return None
         # Power state (func 0x01): 0x01 = off, 0x02 = on.
         if self.coordinator.data.get("power") == 0x01:
-            return HVACMode.OFF
-        mode_code = self.coordinator.data["mode"]
-        # Preset codes (4, 5, 6) don't map to an HVACMode directly — return
-        # the last known base mode so the UI doesn't flip to an unexpected state.
-        if mode_code in self._PRESET_CODES:
-            return self._last_hvac_mode
-        hvac = self._MODE_TO_HVAC.get(mode_code)
-        if hvac is not None:
-            self._last_hvac_mode = hvac
-        return hvac
+            actual = HVACMode.OFF
+        else:
+            mode_code = self.coordinator.data["mode"]
+            # Preset codes (4, 5, 6) don't map to an HVACMode directly — return
+            # the last known base mode so the UI doesn't flip to an unexpected state.
+            if mode_code in self._PRESET_CODES:
+                actual = self._last_hvac_mode
+            else:
+                hvac = self._MODE_TO_HVAC.get(mode_code)
+                if hvac is not None:
+                    self._last_hvac_mode = hvac
+                actual = hvac  # type: ignore[assignment]
+        if self._optimistic_hvac_mode is not None:
+            if actual == self._optimistic_hvac_mode:
+                self._optimistic_hvac_mode = None
+            elif self.coordinator._post_command_fast_polls == 0:
+                self._optimistic_hvac_mode = None
+        return self._optimistic_hvac_mode if self._optimistic_hvac_mode is not None else actual
 
     @property
     def preset_mode(self) -> str | None:
         if self.coordinator.data is None:
             return None
         mode_code = self.coordinator.data["mode"]
-        return self._PRESET_CODES.get(mode_code, AC_PRESET_NONE)
+        actual = self._PRESET_CODES.get(mode_code, AC_PRESET_NONE)
+        if self._optimistic_preset_mode is not None:
+            if actual == self._optimistic_preset_mode:
+                self._optimistic_preset_mode = None
+            elif self.coordinator._post_command_fast_polls == 0:
+                self._optimistic_preset_mode = None
+        return self._optimistic_preset_mode if self._optimistic_preset_mode is not None else actual
 
     @property
     def current_temperature(self) -> float | None:
@@ -409,6 +426,9 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
             code = mode_map.get(hvac_mode)
             if code is not None:
                 await self.coordinator._client.send_command(0x02, bytes([code]))
+        self._optimistic_hvac_mode = hvac_mode
+        self.async_write_ha_state()
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -431,6 +451,9 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
             code = preset_map.get(preset_mode)
             if code is not None:
                 await self.coordinator._client.send_command(0x02, bytes([code]))
+        self._optimistic_preset_mode = preset_mode
+        self.async_write_ha_state()
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -442,14 +465,17 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
         else:
             value = round(temp_c)
         await self.coordinator._client.send_command(0x03, bytes([value]))
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         await self.coordinator._client.send_command(0x04, bytes([int(fan_mode)]))
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         # Protocol: 0x01 = start swing, 0x02 = stop swing.
         value = 0x01 if swing_mode == "on" else 0x02
         await self.coordinator._client.send_command(0x10, bytes([value]))
+        self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()

--- a/custom_components/velit/config_flow.py
+++ b/custom_components/velit/config_flow.py
@@ -38,7 +38,7 @@ from homeassistant.helpers.selector import (
     TextSelector,
 )
 
-from .const import CONF_POLL_INTERVAL, CONF_UNAVAILABLE_ON_FAULT, DEVICE_TYPE_AC, DEVICE_TYPE_HEATER, DOMAIN
+from .const import CONF_POLL_INTERVAL, CONF_UNAVAILABLE_ON_FAULT, DEVICE_TYPE_AC, DEVICE_TYPE_HEATER, DOMAIN, UUID_SERVICE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,6 +128,7 @@ class VelitConfigFlow(ConfigFlow, domain=DOMAIN):
             for info in async_discovered_service_info(self.hass, connectable=True)
             if (info.name and info.name.startswith(_VELIT_NAME_PREFIXES))
             or _VELIT_MANUFACTURER_ID in info.manufacturer_data
+            or UUID_SERVICE in info.service_uuids
         }
 
         if not self._discovered:

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -407,20 +407,19 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
 class VelitACCoordinator(_VelitBaseCoordinator):
     """Coordinator for Velit AC devices (protocol V1.01).
 
-    Polls mode (0x02), temperature (0x03), fan speed (0x04), swing (0x10),
-    inlet air temperature (0x07), and fault info (0x0B) on each cycle.
-
-    Inlet temperature and fault response formats are not fully documented —
-    both are queried and the raw response is stored. Decoded values will be
-    added once response formats are confirmed via hardware capture.
+    Polls power (0x01), mode (0x02), temperature (0x03), fan speed (0x04),
+    swing (0x10), inlet air temperature (0x07), and fault info (0x0B) on
+    each cycle.
 
     Data dict keys:
+      power             int     — 0x01 = off, 0x02 = on (func 0x01 response)
       mode              int     — current operation mode code (see AC protocol 0x02)
       set_temp_c        float   — current setpoint in Celsius
       fan_speed         int     — current fan speed 1–5
       swing             int     — 1 = swinging, 2 = stopped (raw device value)
-      inlet_temp_raw    bytes | None  — raw 0x07 response data (format unconfirmed)
-      fault_raw         bytes | None  — raw 0x0B response data (format unconfirmed)
+      inlet_temp_c      float | None  — inlet air temperature in Celsius (raw byte = °C)
+      fault_code        int     — raw fault code (0 = no fault)
+      fault_name        str     — human-readable fault description
     """
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -429,6 +428,10 @@ class VelitACCoordinator(_VelitBaseCoordinator):
         self._unit_detected = False
 
     async def _async_poll(self) -> dict:
+        power_rsp = await self._client.send_command(0x01, bytes([0x00]))
+        if power_rsp is None:
+            raise UpdateFailed("No response to power query (0x01)")
+
         mode_rsp = await self._client.send_command(0x02, bytes([0x00]))
         if mode_rsp is None:
             raise UpdateFailed("No response to mode query (0x02)")
@@ -445,7 +448,8 @@ class VelitACCoordinator(_VelitBaseCoordinator):
         if swing_rsp is None:
             raise UpdateFailed("No response to swing query (0x10)")
 
-        # Inlet temp and fault formats unconfirmed — log raw, do not raise on failure.
+        # Inlet temp and fault: do not raise on failure — device may not respond
+        # to these while powered off.
         inlet_rsp = await self._client.send_command(0x07, bytes([0x00]))
         fault_rsp = await self._client.send_command(0x0B, bytes([0x00]))
 
@@ -455,11 +459,24 @@ class VelitACCoordinator(_VelitBaseCoordinator):
             self._unit_detected = True
             _LOGGER.debug("AC %s: detected temp unit %s", self._address, self.temp_unit)
 
+        # Inlet temp: single byte, always in Celsius. Confirmed on hardware (0x18 = 24°C).
+        inlet_temp_c: float | None = None
+        if inlet_rsp is not None and inlet_rsp["data"]:
+            inlet_temp_c = float(inlet_rsp["data"][0])
+
+        # Fault: single byte, 0x00 = no fault. Code table not in protocol doc.
+        fault_code = 0
+        if fault_rsp is not None and fault_rsp["data"]:
+            fault_code = fault_rsp["data"][0]
+        fault_name = "No Fault" if fault_code == 0 else f"Unknown ({fault_code})"
+
         return {
+            "power": power_rsp["data"][0],
             "mode": mode_rsp["data"][0],
             "set_temp_c": self.to_celsius(set_temp_raw),
             "fan_speed": fan_rsp["data"][0],
             "swing": swing_rsp["data"][0],
-            "inlet_temp_raw": inlet_rsp["data"] if inlet_rsp else None,
-            "fault_raw": fault_rsp["data"] if fault_rsp else None,
+            "inlet_temp_c": inlet_temp_c,
+            "fault_code": fault_code,
+            "fault_name": fault_name,
         }

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -175,6 +175,23 @@ class _VelitBaseCoordinator(DataUpdateCoordinator):
             return fahrenheit_to_celsius(value)
         return float(value)
 
+    def _adjust_poll_interval(self, machine_state: int) -> None:
+        """Switch to fast polling during active state transitions, restore when settled.
+
+        Also uses fast polling while a cleaning cycle is pending confirmation or
+        while the post-command window is active, so state changes after any
+        command are caught within seconds rather than 30s.
+
+        Pass machine_state=0 for device types that have no transitional states (AC).
+        """
+        if self.cleaning or machine_state in _ACTIVE_MACHINE_STATES or self._post_command_fast_polls > 0:
+            if self.update_interval != _ACTIVE_POLL_INTERVAL:
+                self.update_interval = _ACTIVE_POLL_INTERVAL
+            if self._post_command_fast_polls > 0:
+                self._post_command_fast_polls -= 1
+        elif self.update_interval != self._configured_interval:
+            self.update_interval = self._configured_interval
+
     @abstractmethod
     async def _async_poll(self) -> dict:
         """Issue device queries and return a data dict. Raise UpdateFailed on error."""
@@ -309,21 +326,6 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
                     self._cleaning_timeout_polls = 0
         return data
 
-    def _adjust_poll_interval(self, machine_state: int) -> None:
-        """Switch to fast polling during active state transitions, restore when settled.
-
-        Also uses fast polling while a cleaning cycle is pending confirmation or
-        while the post-command window is active, so state changes after any
-        command are caught within seconds rather than 30s.
-        """
-        if self.cleaning or machine_state in _ACTIVE_MACHINE_STATES or self._post_command_fast_polls > 0:
-            if self.update_interval != _ACTIVE_POLL_INTERVAL:
-                self.update_interval = _ACTIVE_POLL_INTERVAL
-            if self._post_command_fast_polls > 0:
-                self._post_command_fast_polls -= 1
-        elif self.update_interval != self._configured_interval:
-            self.update_interval = self._configured_interval
-
     async def _async_poll(self) -> dict:
         q1 = await self._client.send_command(0x0A, bytes([0x00]))
         if q1 is None:
@@ -426,6 +428,13 @@ class VelitACCoordinator(_VelitBaseCoordinator):
         super().__init__(hass, entry, name=f"Velit AC {entry.data['address']}")
         self._client = VelitACClient(self.hass, self._address)
         self._unit_detected = False
+
+    async def _async_update_data(self) -> dict:
+        data = await super()._async_update_data()
+        # AC has no machine state transitions — pass 0 so only the post-command
+        # fast poll window drives the interval, not machine states.
+        self._adjust_poll_interval(0)
+        return data
 
     async def _async_poll(self) -> dict:
         power_rsp = await self._client.send_command(0x01, bytes([0x00]))

--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -6,7 +6,8 @@
     {"local_name": "VELIT*", "connectable": true},
     {"local_name": "VLIT*", "connectable": true},
     {"local_name": "D30*", "connectable": true},
-    {"manufacturer_id": 22618, "connectable": true}
+    {"manufacturer_id": 22618, "connectable": true},
+    {"service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb", "connectable": true}
   ],
   "codeowners": ["@JohnFreeborg", "@jeremyroe"],
   "config_flow": true,

--- a/custom_components/velit/sensor.py
+++ b/custom_components/velit/sensor.py
@@ -7,7 +7,8 @@ Heater sensors (all sourced from coordinator data):
   - Machine state (human-readable string)
 
 AC sensors:
-  - Fault info (raw bytes, pending format confirmation via hardware capture)
+  - Inlet temperature (always Celsius — AC protocol encodes inlet as raw °C)
+  - Fault code (human-readable string)
 
 All temperature sensors report in Celsius — the coordinator converts from
 the device's active unit before storing values in the data dict.
@@ -35,7 +36,7 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEVICE_TYPE_HEATER, DOMAIN
+from .const import DEVICE_TYPE_AC, DEVICE_TYPE_HEATER, DOMAIN
 from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,6 +80,24 @@ HEATER_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
     ),
 )
 
+# Sensor descriptors for all AC sensors.
+AC_SENSORS: tuple[VelitSensorEntityDescription, ...] = (
+    VelitSensorEntityDescription(
+        key="inlet_temp",
+        data_key="inlet_temp_c",
+        name="Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        # AC inlet temp is always encoded as raw Celsius in the protocol.
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    VelitSensorEntityDescription(
+        key="fault_code",
+        data_key="fault_name",
+        name="Fault",
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -94,8 +113,11 @@ async def async_setup_entry(
               for description in HEATER_SENSORS),
             VelitHeaterPrimeCountdownSensor(coordinator, entry),
         ])
-    else:
-        async_add_entities([VelitACFaultSensorEntity(coordinator, entry)])
+    elif entry.data["device_type"] == DEVICE_TYPE_AC:
+        async_add_entities([
+            VelitACSensorEntity(coordinator, entry, description)
+            for description in AC_SENSORS
+        ])
 
 
 class VelitHeaterSensorEntity(CoordinatorEntity[VelitHeaterCoordinator], SensorEntity):
@@ -166,25 +188,20 @@ class VelitHeaterPrimeCountdownSensor(SensorEntity):
         return self._coordinator.prime_remaining
 
 
-class VelitACFaultSensorEntity(CoordinatorEntity[VelitACCoordinator], SensorEntity):
-    """Exposes raw AC fault query response pending format confirmation.
+class VelitACSensorEntity(CoordinatorEntity[VelitACCoordinator], SensorEntity):
+    """A single sensor entity reading from the AC coordinator data dict."""
 
-    The AC protocol document lists func 0x0B as 'System Fault Info' but does
-    not provide a response format or fault code table. This sensor stores the
-    raw response bytes as a hex string until the format is confirmed via
-    hardware capture and a proper decoder can be added.
-    """
-
-    _attr_name = "Fault Info (raw)"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    entity_description: VelitSensorEntityDescription
 
     def __init__(
         self,
         coordinator: VelitACCoordinator,
         entry: ConfigEntry,
+        description: VelitSensorEntityDescription,
     ) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry.data['address']}_fault_raw"
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.data['address']}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.data["address"])},
             name=entry.data.get(CONF_NAME, entry.data["address"]),
@@ -192,10 +209,7 @@ class VelitACFaultSensorEntity(CoordinatorEntity[VelitACCoordinator], SensorEnti
         )
 
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> float | int | str | None:
         if self.coordinator.data is None:
             return None
-        raw = self.coordinator.data.get("fault_raw")
-        if raw is None:
-            return None
-        return raw.hex()
+        return self.coordinator.data.get(self.entity_description.data_key)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -502,6 +502,15 @@ class TestACClimateActions:
         await entity.async_set_swing_mode("on")
         assert coord._post_command_fast_polls == 6
 
+    async def test_turn_on_restores_last_hvac_mode(self):
+        # Device is off; async_turn_on should power on and restore last mode.
+        entity, coord = _ac_entity(data={**_make_ac_coord().data, "power": 0x01})
+        entity._last_hvac_mode = HVACMode.HEAT
+        await entity.async_turn_on()
+        calls = coord._client.send_command.call_args_list
+        assert calls[0].args == (0x01, bytes([0x02]))   # power on
+        assert calls[1].args == (0x02, bytes([0x02]))   # HEAT = 0x02
+
 
 # ---------------------------------------------------------------------------
 # Heater — icon

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -79,6 +79,7 @@ def _make_ac_coord(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
     coord.async_request_refresh = AsyncMock()
     coord._client = MagicMock()
     coord._client.send_command = AsyncMock()
+    coord._post_command_fast_polls = 0
     return coord
 
 
@@ -325,6 +326,90 @@ class TestACClimateState:
         entity, _ = _ac_entity()
         assert entity.fan_mode == "3"
 
+    def test_hvac_mode_heat(self):
+        data = {**_make_ac_coord().data, "mode": 2}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_mode == HVACMode.HEAT
+
+    def test_hvac_mode_fan_only(self):
+        data = {**_make_ac_coord().data, "mode": 3}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_mode == HVACMode.FAN_ONLY
+
+    def test_hvac_mode_none_when_no_data(self):
+        entity, _ = _ac_entity(data=None)
+        assert entity.hvac_mode is None
+
+    def test_preset_mode_none_when_no_data(self):
+        entity, _ = _ac_entity(data=None)
+        assert entity.preset_mode is None
+
+    def test_current_temperature_from_inlet(self):
+        data = {**_make_ac_coord().data, "inlet_temp_c": 24.0}
+        entity, _ = _ac_entity(data=data)
+        assert entity.current_temperature == 24.0
+
+    def test_current_temperature_none_when_no_data(self):
+        entity, _ = _ac_entity(data=None)
+        assert entity.current_temperature is None
+
+    def test_target_temperature_from_coord(self):
+        entity, _ = _ac_entity()
+        assert entity.target_temperature == 22.0
+
+    def test_target_temperature_none_when_no_data(self):
+        entity, _ = _ac_entity(data=None)
+        assert entity.target_temperature is None
+
+
+# ---------------------------------------------------------------------------
+# AC — optimistic state
+# ---------------------------------------------------------------------------
+
+
+class TestACClimateOptimistic:
+    def test_optimistic_hvac_mode_returned_immediately(self):
+        entity, coord = _ac_entity()
+        # Set optimistic before coordinator confirms.
+        entity._optimistic_hvac_mode = HVACMode.HEAT
+        coord._post_command_fast_polls = 3
+        assert entity.hvac_mode == HVACMode.HEAT
+
+    def test_optimistic_hvac_mode_clears_when_confirmed(self):
+        # Coordinator data already shows HEAT — optimistic agrees, so it clears.
+        data = {**_make_ac_coord().data, "mode": 2}
+        entity, coord = _ac_entity(data=data)
+        entity._optimistic_hvac_mode = HVACMode.HEAT
+        coord._post_command_fast_polls = 3
+        result = entity.hvac_mode
+        assert result == HVACMode.HEAT
+        assert entity._optimistic_hvac_mode is None
+
+    def test_optimistic_hvac_mode_clears_when_fast_polls_exhausted(self):
+        # Fast poll window expired without confirmation — revert to actual.
+        entity, coord = _ac_entity()  # actual = COOL (mode=1)
+        entity._optimistic_hvac_mode = HVACMode.HEAT
+        coord._post_command_fast_polls = 0
+        result = entity.hvac_mode
+        assert result == HVACMode.COOL
+        assert entity._optimistic_hvac_mode is None
+
+    def test_optimistic_preset_mode_returned_immediately(self):
+        entity, coord = _ac_entity()
+        entity._optimistic_preset_mode = AC_PRESET_TURBO
+        coord._post_command_fast_polls = 3
+        assert entity.preset_mode == AC_PRESET_TURBO
+
+    def test_optimistic_preset_mode_clears_when_confirmed(self):
+        # Coordinator data shows turbo (mode=6) — matches optimistic, so it clears.
+        data = {**_make_ac_coord().data, "mode": 6}
+        entity, coord = _ac_entity(data=data)
+        entity._optimistic_preset_mode = AC_PRESET_TURBO
+        coord._post_command_fast_polls = 3
+        result = entity.preset_mode
+        assert result == AC_PRESET_TURBO
+        assert entity._optimistic_preset_mode is None
+
 
 # ---------------------------------------------------------------------------
 # AC — actions
@@ -391,6 +476,31 @@ class TestACClimateActions:
         entity, coord = _ac_entity()
         await entity.async_set_fan_mode("1")
         coord.async_request_refresh.assert_called_once()
+
+    async def test_write_ha_state_called_after_hvac_set(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_hvac_mode(HVACMode.OFF)
+        entity.async_write_ha_state.assert_called_once()
+
+    async def test_write_ha_state_called_after_preset_set(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_preset_mode(AC_PRESET_SLEEP)
+        entity.async_write_ha_state.assert_called_once()
+
+    async def test_post_command_fast_polls_armed_after_temperature(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_temperature(temperature=25.0)
+        assert coord._post_command_fast_polls == 6
+
+    async def test_post_command_fast_polls_armed_after_fan(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_fan_mode("2")
+        assert coord._post_command_fast_polls == 6
+
+    async def test_post_command_fast_polls_armed_after_swing(self):
+        entity, coord = _ac_entity()
+        await entity.async_set_swing_mode("on")
+        assert coord._post_command_fast_polls == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -66,12 +66,14 @@ def _make_heater_coord(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
 def _make_ac_coord(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
     coord = MagicMock()
     coord.data = data if data is not _UNSET else {
+        "power": 0x02,
         "mode": 1,
         "set_temp_c": 22.0,
         "fan_speed": 3,
         "swing": 2,
-        "inlet_temp_raw": None,
-        "fault_raw": None,
+        "inlet_temp_c": None,
+        "fault_code": 0,
+        "fault_name": "No Fault",
     }
     coord.temp_unit = temp_unit
     coord.async_request_refresh = AsyncMock()
@@ -279,7 +281,7 @@ class TestACClimateState:
         assert entity.hvac_mode == HVACMode.COOL
 
     def test_hvac_mode_off(self):
-        data = {**_make_ac_coord().data, "mode": 0}
+        data = {**_make_ac_coord().data, "power": 0x01}
         entity, _ = _ac_entity(data=data)
         assert entity.hvac_mode == HVACMode.OFF
 
@@ -333,7 +335,7 @@ class TestACClimateActions:
         coord._client.send_command.assert_called_once_with(0x01, bytes([0x01]))
 
     async def test_set_hvac_cool(self):
-        entity, coord = _ac_entity(data={**_make_ac_coord().data, "mode": 0})
+        entity, coord = _ac_entity(data={**_make_ac_coord().data, "power": 0x01})
         await entity.async_set_hvac_mode(HVACMode.COOL)
         # Powers on first, then sets mode.
         calls = coord._client.send_command.call_args_list

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -108,6 +108,9 @@ def _ac_entity(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
     entity._attr_name = "Test AC"
     entity._attr_device_info = MagicMock()
     entity._last_hvac_mode = HVACMode.COOL
+    entity._optimistic_hvac_mode = None
+    entity._optimistic_preset_mode = None
+    entity.async_write_ha_state = MagicMock()
     return entity, coord
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -248,18 +248,19 @@ class TestVelitACCoordinatorPoll:
             coord._client = mock_cls.return_value
         return coord
 
-    def _mock_responses(self, mode=1, temp=24, fan=3, swing=2):
+    def _mock_responses(self, power=0x02, mode=1, temp=24, fan=3, swing=2, inlet=0x18, fault=0x00):
         """Build the ordered list of send_command responses for a full AC poll."""
         return [
-            {"data": bytes([mode]), "func": 0x02},   # mode
-            {"data": bytes([temp]), "func": 0x03},   # temp
-            {"data": bytes([fan]),  "func": 0x04},   # fan
-            {"data": bytes([swing]),"func": 0x10},   # swing
-            None,                                     # inlet (unconfirmed format)
-            None,                                     # fault (unconfirmed format)
+            {"data": bytes([power]), "func": 0x01},  # power
+            {"data": bytes([mode]),  "func": 0x02},  # mode
+            {"data": bytes([temp]),  "func": 0x03},  # temp
+            {"data": bytes([fan]),   "func": 0x04},  # fan
+            {"data": bytes([swing]), "func": 0x10},  # swing
+            {"data": bytes([inlet]), "func": 0x07},  # inlet temp
+            {"data": bytes([fault]), "func": 0x0B},  # fault
         ]
 
-    async def test_raises_on_mode_none(self):
+    async def test_raises_on_power_none(self):
         coord = await self._make_coord()
         coord._client.send_command = AsyncMock(return_value=None)
         with pytest.raises(UpdateFailed):
@@ -268,15 +269,17 @@ class TestVelitACCoordinatorPoll:
     async def test_returns_data_on_success(self):
         coord = await self._make_coord()
         coord._client.send_command = AsyncMock(
-            side_effect=self._mock_responses(mode=1, temp=24, fan=3, swing=2)
+            side_effect=self._mock_responses(power=0x02, mode=1, temp=24, fan=3, swing=2, inlet=0x18, fault=0x00)
         )
         data = await coord._async_poll()
+        assert data["power"] == 0x02
         assert data["mode"] == 1
         assert data["set_temp_c"] == 24.0
         assert data["fan_speed"] == 3
         assert data["swing"] == 2
-        assert data["inlet_temp_raw"] is None
-        assert data["fault_raw"] is None
+        assert data["inlet_temp_c"] == 24.0
+        assert data["fault_code"] == 0
+        assert data["fault_name"] == "No Fault"
 
     async def test_unit_detected_celsius(self):
         coord = await self._make_coord()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -297,6 +297,57 @@ class TestVelitACCoordinatorPoll:
         await coord._async_poll()
         assert coord.temp_unit == UnitOfTemperature.FAHRENHEIT
 
+    async def test_raises_on_mid_poll_none(self):
+        coord = await self._make_coord()
+        # Power query succeeds; mode query returns None.
+        coord._client.send_command = AsyncMock(
+            side_effect=[
+                {"data": bytes([0x02]), "func": 0x01},
+                None,
+            ]
+        )
+        with pytest.raises(UpdateFailed):
+            await coord._async_poll()
+
+    async def test_fault_data_decoded_in_poll(self):
+        coord = await self._make_coord()
+        coord._client.send_command = AsyncMock(
+            side_effect=self._mock_responses(fault=0x03)
+        )
+        data = await coord._async_poll()
+        assert data["fault_code"] == 3
+        assert data["fault_name"] != "No Fault"
+
+    def test_adjust_poll_interval_decrements_fast_poll_counter(self):
+        coord = self._make_coord_sync()
+        coord._post_command_fast_polls = 3
+        coord._adjust_poll_interval(0)
+        assert coord._post_command_fast_polls == 2
+
+    def test_adjust_poll_interval_enables_fast_when_pending(self):
+        from datetime import timedelta
+        coord = self._make_coord_sync()
+        coord._post_command_fast_polls = 2
+        coord.update_interval = timedelta(seconds=30)
+        coord._adjust_poll_interval(0)
+        assert coord.update_interval == timedelta(seconds=5)
+
+    def test_adjust_poll_interval_restores_normal_when_idle(self):
+        from datetime import timedelta
+        coord = self._make_coord_sync()
+        coord._post_command_fast_polls = 0
+        coord.update_interval = timedelta(seconds=5)
+        coord._adjust_poll_interval(0)
+        assert coord.update_interval == coord._configured_interval
+
+    def _make_coord_sync(self):
+        hass = _make_hass()
+        entry = _make_entry(device_type="ac")
+        with patch("custom_components.velit.coordinator.VelitACClient") as mock_cls:
+            coord = VelitACCoordinator(hass, entry)
+            coord._client = mock_cls.return_value
+        return coord
+
 
 # ---------------------------------------------------------------------------
 # Fault issue registry

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,9 +11,10 @@ import pytest
 from homeassistant.const import UnitOfTemperature
 
 from custom_components.velit.sensor import (
-    VelitACFaultSensorEntity,
-    VelitHeaterSensorEntity,
+    AC_SENSORS,
     HEATER_SENSORS,
+    VelitACSensorEntity,
+    VelitHeaterSensorEntity,
 )
 
 
@@ -130,32 +131,70 @@ class TestAltitudeUnit:
 
 
 # ---------------------------------------------------------------------------
-# AC fault sensor
+# AC sensors
 # ---------------------------------------------------------------------------
 
+def _make_ac_data(**overrides):
+    base = {
+        "power": 0x02,
+        "mode": 1,
+        "set_temp_c": 22.0,
+        "fan_speed": 3,
+        "swing": 2,
+        "inlet_temp_c": 24.0,
+        "fault_code": 0,
+        "fault_name": "No Fault",
+    }
+    base.update(overrides)
+    return base
 
-class TestACFaultSensor:
-    def _make_entity(self, fault_raw=None):
-        coord = MagicMock()
-        coord.data = {"fault_raw": fault_raw, "mode": 1, "set_temp_c": 22.0,
-                      "fan_speed": 3, "swing": 2, "inlet_temp_raw": None}
-        entry = MagicMock()
-        entry.data = {"address": "AA:BB:CC:DD:EE:FF", "name": "Test AC"}
-        entity = VelitACFaultSensorEntity.__new__(VelitACFaultSensorEntity)
-        entity.coordinator = coord
-        entity._attr_unique_id = "test_ac_fault"
-        entity._attr_device_info = MagicMock()
-        return entity
 
-    def test_none_when_no_data(self):
-        entity = self._make_entity(fault_raw=None)
+def _make_ac_sensor(description, data):
+    coord = MagicMock()
+    coord.data = data
+    entry = MagicMock()
+    entry.data = {"address": "AA:BB:CC:DD:EE:FF", "name": "Test AC"}
+    entity = VelitACSensorEntity.__new__(VelitACSensorEntity)
+    entity.coordinator = coord
+    entity.entity_description = description
+    entity._attr_unique_id = f"AA:BB:CC:DD:EE:FF_{description.key}"
+    entity._attr_device_info = MagicMock()
+    return entity
+
+
+class TestACSensorInletTemp:
+    @pytest.fixture
+    def description(self):
+        return next(d for d in AC_SENSORS if d.key == "inlet_temp")
+
+    def test_returns_inlet_temp(self, description):
+        entity = _make_ac_sensor(description, _make_ac_data(inlet_temp_c=24.0))
+        assert entity.native_value == 24.0
+
+    def test_none_when_inlet_unavailable(self, description):
+        entity = _make_ac_sensor(description, _make_ac_data(inlet_temp_c=None))
         assert entity.native_value is None
 
-    def test_raw_bytes_returned_as_hex(self):
-        entity = self._make_entity(fault_raw=bytes([0x00, 0x01]))
-        assert entity.native_value == "0001"
+    def test_none_when_no_coordinator_data(self, description):
+        entity = _make_ac_sensor(description, _make_ac_data())
+        entity.coordinator.data = None
+        assert entity.native_value is None
 
-    def test_none_coordinator_data_returns_none(self):
-        entity = self._make_entity()
+
+class TestACSensorFault:
+    @pytest.fixture
+    def description(self):
+        return next(d for d in AC_SENSORS if d.key == "fault_code")
+
+    def test_returns_no_fault_string(self, description):
+        entity = _make_ac_sensor(description, _make_ac_data(fault_name="No Fault"))
+        assert entity.native_value == "No Fault"
+
+    def test_returns_unknown_fault_string(self, description):
+        entity = _make_ac_sensor(description, _make_ac_data(fault_name="Unknown (5)"))
+        assert entity.native_value == "Unknown (5)"
+
+    def test_none_when_no_coordinator_data(self, description):
+        entity = _make_ac_sensor(description, _make_ac_data())
         entity.coordinator.data = None
         assert entity.native_value is None


### PR DESCRIPTION
## Summary

- Adds BLE discovery support for Velit AC units, which advertise service UUID `0000ffe0` rather than the name prefixes and manufacturer ID used by heaters
- Implements `VelitACClimateEntity` with full HVAC mode support (off/cool/heat/fan/dry), preset modes (energy saving/sleep/turbo), fan speed, swing, and target temperature
- Adds `VelitACCoordinator` polling all 7 AC status functions (power, mode, temp, fan, swing, inlet temp, fault)
- Adds AC sensor entities: inlet temperature and fault code
- Mirrors heater UX patterns: optimistic state writes, adaptive polling post-command, fault repairs card
- Extends `discover.py` to probe the AC protocol and capture advertisement data; fixes firmware query ordering and documents `ffe0` false positive risk
- Adds `ClimateEntityFeature.TURN_ON`/`TURN_OFF` and `async_turn_on` so the power button toggles correctly in both directions
- 222 tests passing

## Test plan

- [ ] AC BLE discovery: HA surfaces AC unit automatically via `ffe0` service UUID matcher
- [ ] AC config flow: device type selector, entry completes setup
- [ ] Climate entity: hvac_mode, current temperature, target temperature read correctly
- [ ] Mode commands: cool/heat/fan/dry land on device
- [ ] Fan speed and swing commands
- [ ] Optimistic UI: mode changes reflect without waiting for poll
- [ ] AC sensor entities: inlet temp and fault populate correctly
- [ ] Power button: turns off when on, turns on to last mode when off
- [ ] Heater regression: no behaviour change on existing heater entries