### PR TITLE
Add BLE connection switch to AC device

### DIFF
--- a/custom_components/velit/switch.py
+++ b/custom_components/velit/switch.py
@@ -8,7 +8,9 @@ Heater:
     restarting the integration.
 
 AC:
-  No switch entities at this time.
+  VelitACBLESwitch — same behaviour as the heater BLE switch. BLE allows
+    only a single connection; releasing the connection lets the Velit mobile
+    app pair while keeping the integration entry intact.
 """
 
 from __future__ import annotations
@@ -24,8 +26,8 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DEVICE_TYPE_HEATER, DOMAIN
-from .coordinator import VelitHeaterCoordinator
+from .const import DEVICE_TYPE_AC, DEVICE_TYPE_HEATER, DOMAIN
+from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,15 +38,18 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Velit switch entities from a config entry."""
-    if entry.data["device_type"] != DEVICE_TYPE_HEATER:
-        return
-
-    coordinator: VelitHeaterCoordinator = entry.runtime_data
-    async_add_entities([
-        VelitHeaterBLESwitch(coordinator, entry),
-        VelitHeaterFuelPrimingSwitch(coordinator, entry),
-        VelitHeaterCleaningSwitch(coordinator, entry),
-    ])
+    if entry.data["device_type"] == DEVICE_TYPE_HEATER:
+        coordinator: VelitHeaterCoordinator = entry.runtime_data
+        async_add_entities([
+            VelitHeaterBLESwitch(coordinator, entry),
+            VelitHeaterFuelPrimingSwitch(coordinator, entry),
+            VelitHeaterCleaningSwitch(coordinator, entry),
+        ])
+    elif entry.data["device_type"] == DEVICE_TYPE_AC:
+        ac_coordinator: VelitACCoordinator = entry.runtime_data
+        async_add_entities([
+            VelitACBLESwitch(ac_coordinator, entry),
+        ])
 
 
 class VelitHeaterBLESwitch(CoordinatorEntity[VelitHeaterCoordinator], SwitchEntity):
@@ -235,4 +240,55 @@ class VelitHeaterCleaningSwitch(CoordinatorEntity[VelitHeaterCoordinator], Switc
         Pushes state back immediately so the UI snaps back to on rather than
         appearing to accept the off command.
         """
+        self.async_write_ha_state()
+
+
+class VelitACBLESwitch(CoordinatorEntity[VelitACCoordinator], SwitchEntity):
+    """Toggle switch for the AC BLE connection.
+
+    On  — BLE connected, coordinator polling normally.
+    Off — BLE disconnected, reconnect loop suppressed. The device is free
+          for other apps (e.g. the Velit mobile app) to use.
+
+    Turning the switch back on triggers an immediate connect attempt. If it
+    fails (device busy), the switch stays off and the user can retry.
+    """
+
+    _attr_name = "BLE Connection"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:bluetooth"
+
+    def __init__(
+        self,
+        coordinator: VelitACCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.data['address']}_ble_connection"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data["address"])},
+            name=entry.data.get(CONF_NAME, entry.data["address"]),
+            manufacturer="Velit",
+        )
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator._client.connected
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Connect to the device and resume polling."""
+        try:
+            await self.coordinator._client.connect()
+            await self.coordinator.async_request_refresh()
+        except Exception as exc:
+            _LOGGER.warning("BLE reconnect failed: %s", exc)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disconnect from the device and suppress automatic reconnection."""
+        await self.coordinator._client.disconnect()
         self.async_write_ha_state()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,4 @@
-"""Unit tests for VelitHeaterBLESwitch, VelitHeaterFuelPrimingSwitch, and VelitHeaterCleaningSwitch."""
+"""Unit tests for Velit switch entities (heater and AC)."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.velit.switch import (
+    VelitACBLESwitch,
     VelitHeaterBLESwitch,
     VelitHeaterCleaningSwitch,
     VelitHeaterFuelPrimingSwitch,
@@ -105,6 +106,95 @@ class TestBLESwitchActions:
     def test_unique_id(self):
         entity, _ = _make_entity()
         assert entity._attr_unique_id == "AA:BB:CC:DD:EE:FF_ble_connection"
+
+
+# ---------------------------------------------------------------------------
+# AC BLE switch helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ac_entry(address="C7:87:3B:49:AE:37"):
+    entry = MagicMock()
+    entry.data = {"device_type": "ac", "address": address, "name": "Test AC"}
+    return entry
+
+
+def _make_ac_ble_entity(connected=True):
+    coord = MagicMock()
+    coord._client = MagicMock()
+    coord._client.connected = connected
+    coord._client.connect = AsyncMock()
+    coord._client.disconnect = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
+    entry = _make_ac_entry()
+    entity = VelitACBLESwitch.__new__(VelitACBLESwitch)
+    entity.coordinator = coord
+    entity._attr_unique_id = f"{entry.data['address']}_ble_connection"
+    entity._attr_name = "BLE Connection"
+    entity._attr_device_info = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+    return entity, coord
+
+
+# ---------------------------------------------------------------------------
+# AC BLE switch — state
+# ---------------------------------------------------------------------------
+
+
+class TestACBLESwitchState:
+    def test_is_on_when_connected(self):
+        entity, _ = _make_ac_ble_entity(connected=True)
+        assert entity.is_on is True
+
+    def test_is_off_when_disconnected(self):
+        entity, _ = _make_ac_ble_entity(connected=False)
+        assert entity.is_on is False
+
+    def test_always_available(self):
+        entity, _ = _make_ac_ble_entity(connected=False)
+        assert entity.available is True
+
+
+# ---------------------------------------------------------------------------
+# AC BLE switch — actions
+# ---------------------------------------------------------------------------
+
+
+class TestACBLESwitchActions:
+    async def test_turn_off_calls_disconnect(self):
+        entity, coord = _make_ac_ble_entity(connected=True)
+        await entity.async_turn_off()
+        coord._client.disconnect.assert_awaited_once()
+
+    async def test_turn_off_writes_state(self):
+        entity, _ = _make_ac_ble_entity(connected=True)
+        await entity.async_turn_off()
+        entity.async_write_ha_state.assert_called_once()
+
+    async def test_turn_on_calls_connect(self):
+        entity, coord = _make_ac_ble_entity(connected=False)
+        await entity.async_turn_on()
+        coord._client.connect.assert_awaited_once()
+
+    async def test_turn_on_requests_refresh_on_success(self):
+        entity, coord = _make_ac_ble_entity(connected=False)
+        await entity.async_turn_on()
+        coord.async_request_refresh.assert_awaited_once()
+
+    async def test_turn_on_writes_state(self):
+        entity, _ = _make_ac_ble_entity(connected=False)
+        await entity.async_turn_on()
+        entity.async_write_ha_state.assert_called_once()
+
+    async def test_turn_on_does_not_raise_on_connect_failure(self):
+        entity, coord = _make_ac_ble_entity(connected=False)
+        coord._client.connect = AsyncMock(side_effect=Exception("BLE busy"))
+        await entity.async_turn_on()
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_unique_id(self):
+        entity, _ = _make_ac_ble_entity()
+        assert entity._attr_unique_id == "C7:87:3B:49:AE:37_ble_connection"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
AC devices share the same single-connection BLE constraint as heaters.
VelitACBLESwitch mirrors the heater implementation — always available,
reflects connection state, connect/disconnect on toggle.

10 tests added covering toggle, state reflection, and availability.

Note: not yet validated on AC hardware. Needs a tester with a
Velit AC unit to confirm connect/disconnect behaviour before merge.