### PR TITLE
Fix AC discovery

### DIFF
--- a/custom_components/velit/config_flow.py
+++ b/custom_components/velit/config_flow.py
@@ -44,7 +44,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # BLE advertisement name prefixes that identify Velit devices, matching the
 # manifest.json bluetooth matchers.
-_VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30", "KT")
+_VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30", "KT2")
 
 # BEKEN Corp manufacturer ID (0x585A = 22618), present in all known Velit
 # advertisements. Some firmware versions advertise with the MAC as the local

--- a/custom_components/velit/config_flow.py
+++ b/custom_components/velit/config_flow.py
@@ -44,7 +44,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # BLE advertisement name prefixes that identify Velit devices, matching the
 # manifest.json bluetooth matchers.
-_VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30")
+_VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30", "KT")
 
 # BEKEN Corp manufacturer ID (0x585A = 22618), present in all known Velit
 # advertisements. Some firmware versions advertise with the MAC as the local

--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -6,7 +6,7 @@
     {"local_name": "VELIT*", "connectable": true},
     {"local_name": "VLIT*", "connectable": true},
     {"local_name": "D30*", "connectable": true},
-    {"local_name": "KT*", "connectable": true},
+    {"local_name": "KT2*", "connectable": true},
     {"manufacturer_id": 22618, "connectable": true},
     {"service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb", "connectable": true}
   ],

--- a/custom_components/velit/manifest.json
+++ b/custom_components/velit/manifest.json
@@ -6,6 +6,7 @@
     {"local_name": "VELIT*", "connectable": true},
     {"local_name": "VLIT*", "connectable": true},
     {"local_name": "D30*", "connectable": true},
+    {"local_name": "KT*", "connectable": true},
     {"manufacturer_id": 22618, "connectable": true},
     {"service_uuid": "0000ffe0-0000-1000-8000-00805f9b34fb", "connectable": true}
   ],

--- a/tools/discover.py
+++ b/tools/discover.py
@@ -57,7 +57,7 @@ from bleak.backends.scanner import AdvertisementData
 # BLE advertisement local name prefixes used by known Velit heater firmware.
 # AC units may advertise with different names (e.g. "LS Dis Server" observed
 # on a 2000R unit). The service UUID filter below is more reliable.
-_VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30")
+_VELIT_NAME_PREFIXES = ("VELIT", "VLIT", "D30", "KT")
 
 # BEKEN Corp manufacturer ID (0x585A = 22618), present in known Velit heater
 # advertisements. Whether AC units share this ID is unconfirmed.


### PR DESCRIPTION
Add KT2* as a matching prefix for the 2000R AC BLE GAP advertisements.  This enables the AC to be auto-discovered by both the tools/discover.py script and the integration.