### PR TITLE
fix: clamp setpoint range to device °F boundaries

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -37,7 +37,7 @@ from .const import (
     AC_MIN_TEMP_C,
 )
 from .coordinator import VelitACCoordinator, VelitHeaterCoordinator
-from .packet_utils import celsius_to_fahrenheit
+from .packet_utils import celsius_to_fahrenheit, fahrenheit_to_celsius
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,8 +96,17 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     _attr_preset_modes = ["Auto", "Manual"]
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
-    _attr_min_temp = float(HEATER_MIN_TEMP_C)
-    _attr_max_temp = float(HEATER_MAX_TEMP_C)
+    @property
+    def min_temp(self) -> float:
+        if self.coordinator.temp_unit == UnitOfTemperature.FAHRENHEIT:
+            return fahrenheit_to_celsius(40)
+        return float(HEATER_MIN_TEMP_C)
+
+    @property
+    def max_temp(self) -> float:
+        if self.coordinator.temp_unit == UnitOfTemperature.FAHRENHEIT:
+            return fahrenheit_to_celsius(99)
+        return float(HEATER_MAX_TEMP_C)
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.PRESET_MODE


### PR DESCRIPTION
When the device operates in Fahrenheit mode, HA converts the user's °F
input to °C internally before validating against the entity's min/max.
The static limits of 4–37°C caused two problems:

- 99°F (37.22°C) exceeded the 37°C ceiling and was rejected, even
  though 99°F is the device maximum.
- 39°F (3.89°C) fell below the 4°C floor and was rejected, but the
  actual device minimum is 40°F (4.44°C), so 39°F should be
  unreachable regardless.

Fix: replace the static class-level min/max attributes with properties
that return the exact °C equivalents of 40°F and 99°F when the device
is in Fahrenheit mode. Celsius users are unaffected — the 4–37°C
limits are unchanged.

Closes #33