### PR TITLE
fix: heater gear control, AC swing removal, altitude bounds

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -83,19 +83,39 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     """Climate entity for a Velit heater (protocol V1.02).
 
     HVAC modes:
-      OFF      — heater is shut down
-      HEAT     — heater running (Auto or Manual preset)
-      FAN_ONLY — ventilation only, no combustion (protocol 0x03/0x04)
+      OFF   — heater is shut down
+      HEAT  — heater running (Auto or Manual preset)
 
     Presets (only meaningful in HEAT mode):
-      Auto    — device controls burner level automatically to hit setpoint
-      Manual  — fixed burner level (gear), thermostat inactive
+      Auto   — device controls burner level automatically to hit setpoint
+      Manual — fixed burner level (gear), thermostat inactive
+
+    Fan modes (gear 1–5, only available in Manual preset):
+      Gear selector is hidden in Auto — the device controls level automatically
+      and allowing the user to set it there would have no effect.
     """
 
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.FAN_ONLY]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
     _attr_preset_modes = ["Auto", "Manual"]
+    _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
+
+    @property
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return supported features, adding FAN_MODE only in Manual preset.
+
+        Gear control is meaningless in Auto — the device picks the level. Hiding
+        the selector prevents users from sending a gear command that would be ignored.
+        """
+        features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.PRESET_MODE
+        )
+        if self.preset_mode == "Manual":
+            features |= ClimateEntityFeature.FAN_MODE
+        return features
+
     @property
     def min_temp(self) -> float:
         if self.coordinator.temp_unit == UnitOfTemperature.FAHRENHEIT:
@@ -107,11 +127,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         if self.coordinator.temp_unit == UnitOfTemperature.FAHRENHEIT:
             return fahrenheit_to_celsius(99)
         return float(HEATER_MAX_TEMP_C)
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.PRESET_MODE
-    )
-
     def __init__(
         self,
         coordinator: VelitHeaterCoordinator,
@@ -127,9 +142,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         # post-command fast poll window expires (command not accepted by device).
         self._optimistic_hvac_mode: HVACMode | None = None
         self._optimistic_preset_mode: str | None = None
-        # Ventilation state is tracked here because the device does not report
-        # it in Q1 — the protocol has no ventilation machine_state value.
-        self._ventilating: bool = False
 
     # ------------------------------------------------------------------
     # State properties — read from coordinator data, never from device
@@ -159,9 +171,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     def hvac_mode(self) -> HVACMode | None:
         if self.coordinator.data is None:
             return None
-        if self._ventilating:
-            actual = HVACMode.FAN_ONLY
-        elif self.coordinator.data["machine_state"] in (0, 2):
+        if self.coordinator.data["machine_state"] in (0, 2):
             actual = HVACMode.OFF
         else:
             actual = HVACMode.HEAT
@@ -177,8 +187,8 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
 
     @property
     def preset_mode(self) -> str | None:
-        # Presets only apply in HEAT mode — hide selector in FAN_ONLY and OFF.
-        if self.coordinator.data is None or self._ventilating:
+        # Presets only apply in HEAT mode — hide selector in OFF.
+        if self.coordinator.data is None:
             return None
         work_mode = self.coordinator.data["work_mode"]
         actual = "Auto" if work_mode == _HEATER_MODE_THERMOSTAT else "Manual"
@@ -210,8 +220,6 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
         """
         if self.coordinator.data is None:
             return None
-        if self._ventilating:
-            return HVACAction.FAN
         # Any active fault — device is not operational.
         if self.coordinator.data["fault_code"] != 0:
             return HVACAction.OFF
@@ -243,6 +251,12 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
             "fault": self.coordinator.data.get("fault_name"),
         }
 
+    @property
+    def fan_mode(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        return str(self.coordinator.data["current_gear"])
+
     # ------------------------------------------------------------------
     # Actions — send command then refresh to confirm state
     # ------------------------------------------------------------------
@@ -250,22 +264,18 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator._client.send_command(0x02, bytes([0x00]))
-            self._ventilating = False
         elif hvac_mode == HVACMode.HEAT:
-            if self._ventilating:
-                # Stop ventilation before starting heat. Firmware behaviour on
-                # direct FAN_ONLY → HEAT transition is untested — see TODOS.
-                await self.coordinator._client.send_command(0x04, bytes([0x00]))
-                self._ventilating = False
             mode_byte = 0x02 if self.preset_mode == "Auto" else 0x01
             await self.coordinator._client.send_command(0x01, bytes([mode_byte]))
-        elif hvac_mode == HVACMode.FAN_ONLY:
-            await self.coordinator._client.send_command(0x03, bytes([0x00]))
-            self._ventilating = True
         # Write expected state immediately so the UI responds without waiting
         # for the next poll. Coordinator confirmation or window expiry clears it.
         self._optimistic_hvac_mode = hvac_mode
         self.async_write_ha_state()
+        self.coordinator._post_command_fast_polls = 6
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        await self.coordinator._client.send_command(0x07, bytes([int(fan_mode)]))
         self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 
@@ -315,7 +325,6 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.DRY]
     _attr_preset_modes = [AC_PRESET_NONE, AC_PRESET_ENERGY_SAVING, AC_PRESET_SLEEP, AC_PRESET_TURBO]
     _attr_fan_modes = FAN_MODES
-    _attr_swing_modes = ["off", "on"]
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
     _attr_min_temp = float(AC_MIN_TEMP_C)
@@ -324,7 +333,6 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.PRESET_MODE
         | ClimateEntityFeature.FAN_MODE
-        | ClimateEntityFeature.SWING_MODE
         | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TURN_OFF
     )
@@ -422,13 +430,6 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
             return None
         return str(self.coordinator.data["fan_speed"])
 
-    @property
-    def swing_mode(self) -> str | None:
-        if self.coordinator.data is None:
-            return None
-        # Protocol: 1 = start swing, 2 = stop swing.
-        return "on" if self.coordinator.data["swing"] == 1 else "off"
-
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator._client.send_command(0x01, bytes([0x01]))
@@ -489,13 +490,6 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         await self.coordinator._client.send_command(0x04, bytes([int(fan_mode)]))
-        self.coordinator._post_command_fast_polls = 6
-        await self.coordinator.async_request_refresh()
-
-    async def async_set_swing_mode(self, swing_mode: str) -> None:
-        # Protocol: 0x01 = start swing, 0x02 = stop swing.
-        value = 0x01 if swing_mode == "on" else 0x02
-        await self.coordinator._client.send_command(0x10, bytes([value]))
         self.coordinator._post_command_fast_polls = 6
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -442,7 +442,6 @@ class VelitACCoordinator(_VelitBaseCoordinator):
       mode              int     — current operation mode code (see AC protocol 0x02)
       set_temp_c        float   — current setpoint in Celsius
       fan_speed         int     — current fan speed 1–5
-      swing             int     — 1 = swinging, 2 = stopped (raw device value)
       inlet_temp_c      float | None  — inlet air temperature in Celsius (raw byte = °C)
       fault_code        int     — raw fault code (0 = no fault)
       fault_name        str     — human-readable fault description
@@ -477,10 +476,6 @@ class VelitACCoordinator(_VelitBaseCoordinator):
         if fan_rsp is None:
             raise UpdateFailed("No response to fan speed query (0x04)")
 
-        swing_rsp = await self._client.send_command(0x10, bytes([0x00]))
-        if swing_rsp is None:
-            raise UpdateFailed("No response to swing query (0x10)")
-
         # Inlet temp and fault: do not raise on failure — device may not respond
         # to these while powered off.
         inlet_rsp = await self._client.send_command(0x07, bytes([0x00]))
@@ -508,7 +503,6 @@ class VelitACCoordinator(_VelitBaseCoordinator):
             "mode": mode_rsp["data"][0],
             "set_temp_c": self.to_celsius(set_temp_raw),
             "fan_speed": fan_rsp["data"][0],
-            "swing": swing_rsp["data"][0],
             "inlet_temp_c": inlet_temp_c,
             "fault_code": fault_code,
             "fault_name": fault_name,

--- a/custom_components/velit/coordinator.py
+++ b/custom_components/velit/coordinator.py
@@ -51,6 +51,13 @@ _CELSIUS_SETPOINT_MAX = 37
 _FAHRENHEIT_SETPOINT_MIN = 40
 _FAHRENHEIT_SETPOINT_MAX = 99
 
+# Maximum plausible altitude per unit. Values above these indicate an
+# uninitialized or garbage sensor reading and are reported as None.
+# Bounds are deliberately generous (well above Everest) to avoid masking
+# legitimate high-altitude use while still filtering device startup glitches.
+_MAX_ALTITUDE_M = 9000   # metres — above Everest (8849 m)
+_MAX_ALTITUDE_FT = 30000 # feet   — above Everest (29032 ft)
+
 # Heater fault codes from protocol V1.02.
 HEATER_FAULT_CODES: dict[int, str] = {
     0: "No Fault",
@@ -80,6 +87,19 @@ HEATER_MACHINE_STATES: dict[int, str] = {
     4: "Cleaning",
     5: "Clean Complete",
 }
+
+
+def _validate_altitude(raw: int, unit: str) -> int | None:
+    """Return raw altitude if plausible, else None.
+
+    Filters the 0xFFFF unavailable sentinel and values above a generous
+    ceiling that no camping heater could realistically report. Startup glitches
+    sometimes produce large non-sentinel values before the sensor initialises.
+    """
+    if raw == 0xFFFF:
+        return None
+    max_alt = _MAX_ALTITUDE_FT if unit == UnitOfTemperature.FAHRENHEIT else _MAX_ALTITUDE_M
+    return raw if raw <= max_alt else None
 
 
 class _VelitBaseCoordinator(DataUpdateCoordinator):
@@ -426,7 +446,7 @@ class VelitHeaterCoordinator(_VelitBaseCoordinator):
             "inlet_temp_c": self.to_celsius(inlet_native) if inlet_native is not None else None,
             "casing_temp_c": self.to_celsius(casing_native) if casing_native is not None else None,
             "outlet_temp_c": self.to_celsius(outlet_native) if outlet_native is not None else None,
-            "altitude": alt_raw if alt_raw != 0xFFFF else None,
+            "altitude": _validate_altitude(alt_raw, self.temp_unit),
         }
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from homeassistant.components.climate import HVACAction, HVACMode
+from homeassistant.components.climate import ClimateEntityFeature, HVACAction, HVACMode
 from homeassistant.const import UnitOfTemperature
 
 from custom_components.velit.climate import (
@@ -70,7 +70,6 @@ def _make_ac_coord(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS):
         "mode": 1,
         "set_temp_c": 22.0,
         "fan_speed": 3,
-        "swing": 2,
         "inlet_temp_c": None,
         "fault_code": 0,
         "fault_name": "No Fault",
@@ -94,7 +93,6 @@ def _heater_entity(data=_UNSET, temp_unit=UnitOfTemperature.CELSIUS, options=Non
     entity._attr_device_info = MagicMock()
     entity._optimistic_hvac_mode = None
     entity._optimistic_preset_mode = None
-    entity._ventilating = False
     entity.async_write_ha_state = MagicMock()
     return entity, coord
 
@@ -146,20 +144,22 @@ class TestHeaterClimateState:
         entity, _ = _heater_entity()
         assert entity.target_temperature == pytest.approx(22.0)
 
-    def test_hvac_mode_fan_only_when_ventilating(self):
+    def test_fan_mode_returns_current_gear(self):
         entity, _ = _heater_entity()
-        entity._ventilating = True
-        assert entity.hvac_mode == HVACMode.FAN_ONLY
+        assert entity.fan_mode == "3"
 
-    def test_preset_none_when_ventilating(self):
-        entity, _ = _heater_entity()
-        entity._ventilating = True
-        assert entity.preset_mode is None
+    def test_fan_mode_none_when_no_data(self):
+        entity, _ = _heater_entity(data=None)
+        assert entity.fan_mode is None
 
-    def test_hvac_action_fan_when_ventilating(self):
-        entity, _ = _heater_entity()
-        entity._ventilating = True
-        assert entity.hvac_action == HVACAction.FAN
+    def test_supported_features_include_fan_mode_in_manual(self):
+        entity, _ = _heater_entity()  # default data: work_mode=1 (Manual)
+        assert ClimateEntityFeature.FAN_MODE in entity.supported_features
+
+    def test_supported_features_exclude_fan_mode_in_auto(self):
+        data = {**_make_heater_coord().data, "work_mode": 2}
+        entity, _ = _heater_entity(data=data)
+        assert ClimateEntityFeature.FAN_MODE not in entity.supported_features
 
     def test_hvac_action_heating_when_normal(self):
         data = {**_make_heater_coord().data, "machine_state": 1, "fault_code": 0}
@@ -225,26 +225,15 @@ class TestHeaterClimateActions:
         await entity.async_set_hvac_mode(HVACMode.HEAT)
         coord._client.send_command.assert_called_once_with(0x01, bytes([0x02]))
 
-    async def test_set_hvac_fan_only(self):
+    async def test_set_fan_mode_sends_gear_command(self):
         entity, coord = _heater_entity()
-        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
-        coord._client.send_command.assert_called_once_with(0x03, bytes([0x00]))
-        assert entity._ventilating is True
+        await entity.async_set_fan_mode("4")
+        coord._client.send_command.assert_called_once_with(0x07, bytes([4]))
 
-    async def test_set_hvac_off_clears_ventilating(self):
+    async def test_set_fan_mode_arms_fast_polls(self):
         entity, coord = _heater_entity()
-        entity._ventilating = True
-        await entity.async_set_hvac_mode(HVACMode.OFF)
-        assert entity._ventilating is False
-
-    async def test_set_hvac_heat_from_fan_only_stops_ventilation_first(self):
-        entity, coord = _heater_entity()
-        entity._ventilating = True
-        await entity.async_set_hvac_mode(HVACMode.HEAT)
-        calls = coord._client.send_command.call_args_list
-        assert calls[0] == ((0x04, bytes([0x00])),)
-        assert calls[1][0][0] == 0x01
-        assert entity._ventilating is False
+        await entity.async_set_fan_mode("2")
+        assert coord._post_command_fast_polls == 6
 
     async def test_set_preset_auto(self):
         entity, coord = _heater_entity()
@@ -268,9 +257,9 @@ class TestHeaterClimateActions:
         await entity.async_set_temperature(temperature=24.0)
         coord._client.send_command.assert_called_once_with(0x08, bytes([75]))
 
-    async def test_refresh_called_after_each_action(self):
+    async def test_refresh_called_after_fan_mode(self):
         entity, coord = _heater_entity()
-        await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
+        await entity.async_set_fan_mode("3")
         coord.async_request_refresh.assert_called_once()
 
 
@@ -312,15 +301,6 @@ class TestACClimateState:
         data = {**_make_ac_coord().data, "mode": 6}
         entity, _ = _ac_entity(data=data)
         assert entity.preset_mode == AC_PRESET_TURBO
-
-    def test_swing_on(self):
-        data = {**_make_ac_coord().data, "swing": 1}
-        entity, _ = _ac_entity(data=data)
-        assert entity.swing_mode == "on"
-
-    def test_swing_off(self):
-        entity, _ = _ac_entity()
-        assert entity.swing_mode == "off"
 
     def test_fan_mode(self):
         entity, _ = _ac_entity()
@@ -462,16 +442,6 @@ class TestACClimateActions:
         await entity.async_set_fan_mode("4")
         coord._client.send_command.assert_called_once_with(0x04, bytes([4]))
 
-    async def test_set_swing_on(self):
-        entity, coord = _ac_entity()
-        await entity.async_set_swing_mode("on")
-        coord._client.send_command.assert_called_once_with(0x10, bytes([0x01]))
-
-    async def test_set_swing_off(self):
-        entity, coord = _ac_entity()
-        await entity.async_set_swing_mode("off")
-        coord._client.send_command.assert_called_once_with(0x10, bytes([0x02]))
-
     async def test_refresh_called_after_action(self):
         entity, coord = _ac_entity()
         await entity.async_set_fan_mode("1")
@@ -495,11 +465,6 @@ class TestACClimateActions:
     async def test_post_command_fast_polls_armed_after_fan(self):
         entity, coord = _ac_entity()
         await entity.async_set_fan_mode("2")
-        assert coord._post_command_fast_polls == 6
-
-    async def test_post_command_fast_polls_armed_after_swing(self):
-        entity, coord = _ac_entity()
-        await entity.async_set_swing_mode("on")
         assert coord._post_command_fast_polls == 6
 
     async def test_turn_on_restores_last_hvac_mode(self):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -180,6 +180,33 @@ class TestVelitHeaterCoordinatorParse:
         assert data["outlet_temp_c"] is None
         assert data["altitude"] is None
 
+    def test_altitude_implausible_returns_none_fahrenheit(self):
+        """Non-0xFFFF garbage values above the ceiling must be filtered."""
+        q2 = bytearray(Q2_DATA)
+        q2[11] = 0x80  # 0x8001 = 32769 ft — above _MAX_ALTITUDE_FT (30000)
+        q2[12] = 0x01
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_F, bytes(q2))
+        assert data["altitude"] is None
+
+    def test_altitude_implausible_returns_none_celsius(self):
+        q2 = bytearray(Q2_DATA)
+        q2[11] = 0x27  # 0x2711 = 10001 m — above _MAX_ALTITUDE_M (9000)
+        q2[12] = 0x11
+        coord = self._make_coord()
+        # Force Celsius mode by using Q1_DATA_C
+        data = coord._parse(Q1_DATA_C, bytes(q2))
+        assert data["altitude"] is None
+
+    def test_altitude_at_ceiling_is_valid(self):
+        """Values exactly at the bound must pass through."""
+        q2 = bytearray(Q2_DATA)
+        q2[11] = 0x23  # 0x2328 = 9000 m exactly
+        q2[12] = 0x28
+        coord = self._make_coord()
+        data = coord._parse(Q1_DATA_C, bytes(q2))
+        assert data["altitude"] == 9000
+
     def test_gear_and_work_mode(self):
         coord = self._make_coord()
         data = coord._parse(Q1_DATA_F, Q2_DATA)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -299,14 +299,13 @@ class TestVelitACCoordinatorPoll:
             coord._client = mock_cls.return_value
         return coord
 
-    def _mock_responses(self, power=0x02, mode=1, temp=24, fan=3, swing=2, inlet=0x18, fault=0x00):
+    def _mock_responses(self, power=0x02, mode=1, temp=24, fan=3, inlet=0x18, fault=0x00):
         """Build the ordered list of send_command responses for a full AC poll."""
         return [
             {"data": bytes([power]), "func": 0x01},  # power
             {"data": bytes([mode]),  "func": 0x02},  # mode
             {"data": bytes([temp]),  "func": 0x03},  # temp
             {"data": bytes([fan]),   "func": 0x04},  # fan
-            {"data": bytes([swing]), "func": 0x10},  # swing
             {"data": bytes([inlet]), "func": 0x07},  # inlet temp
             {"data": bytes([fault]), "func": 0x0B},  # fault
         ]
@@ -320,14 +319,13 @@ class TestVelitACCoordinatorPoll:
     async def test_returns_data_on_success(self):
         coord = await self._make_coord()
         coord._client.send_command = AsyncMock(
-            side_effect=self._mock_responses(power=0x02, mode=1, temp=24, fan=3, swing=2, inlet=0x18, fault=0x00)
+            side_effect=self._mock_responses(power=0x02, mode=1, temp=24, fan=3, inlet=0x18, fault=0x00)
         )
         data = await coord._async_poll()
         assert data["power"] == 0x02
         assert data["mode"] == 1
         assert data["set_temp_c"] == 24.0
         assert data["fan_speed"] == 3
-        assert data["swing"] == 2
         assert data["inlet_temp_c"] == 24.0
         assert data["fault_code"] == 0
         assert data["fault_name"] == "No Fault"


### PR DESCRIPTION
## Summary

- Heater gear control (levels 1–5) exposed via fan mode selector, visible only in Manual preset. Gear changes use command 0x07.
- Removed FAN_ONLY HVAC mode from the heater entity — the ventilation command (0x03/0x04) is non-functional on current hardware per vendor confirmation.
- Removed AC swing mode — not supported on current hardware per vendor confirmation. Swing query (func 0x10) also dropped from AC coordinator poll cycle.
- Filtered implausible altitude readings. Previously only 0xFFFF was treated as unavailable. On first install the device can emit other large non-sentinel values before sensors initialise. Added unit-aware ceilings (9000 m / 30000 ft) so garbage readings return None and the sensor shows "Unknown" rather than a spurious large number.

## Test plan

- [ ] Heater in Manual preset: fan mode selector appears with levels 1–5
- [ ] Heater in Auto preset: fan mode selector is hidden
- [ ] FAN_ONLY option no longer appears in heater HVAC mode list
- [ ] AC entity has no swing mode control
- [ ] Gear change sends over BLE and heater responds at the selected level
- [ ] Altitude sensor shows a plausible value (not "Unknown") during normal operation
- [ ] All 234 unit tests pass