### PR TITLE
fix: AC cooling tile — remove unsupported modes, add hvac_action

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -424,6 +424,33 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
             return None
         return str(self.coordinator.data["fan_speed"])
 
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Current action shown on the climate tile.
+
+        Derived from power state and mode — the AC protocol provides no
+        dedicated active/idle signal, so this reflects the configured mode
+        rather than whether the compressor is actively cycling.
+        """
+        if self.coordinator.data is None:
+            return None
+        if self.coordinator.data.get("fault_code", 0) != 0:
+            return HVACAction.OFF
+        if self.coordinator.data.get("power") == 0x01:
+            return HVACAction.OFF
+        mode_code = self.coordinator.data["mode"]
+        # Preset codes don't carry their own action — resolve from last base mode.
+        if mode_code in self._PRESET_CODES:
+            base = self._last_hvac_mode
+        else:
+            base = self._MODE_TO_HVAC.get(mode_code, self._last_hvac_mode)
+        if base == HVACMode.COOL:
+            return HVACAction.COOLING
+        if base == HVACMode.FAN_ONLY:
+            return HVACAction.FAN
+        return HVACAction.IDLE
+
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         if hvac_mode == HVACMode.OFF:
             await self.coordinator._client.send_command(0x01, bytes([0x01]))

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -47,12 +47,10 @@ _HEATER_MODE_THERMOSTAT = 2
 
 # AC operation mode codes (func 0x02).
 _AC_MODE_COOL = 1
-_AC_MODE_HEAT = 2
 _AC_MODE_FAN = 3
 _AC_MODE_ENERGY_SAVING = 4
 _AC_MODE_SLEEP = 5
 _AC_MODE_TURBO = 6
-_AC_MODE_DEHUMIDIFY = 7
 _AC_MODE_VENT = 8
 
 # Preset names used in HA for AC modes that don't map directly to HVACMode.
@@ -308,9 +306,7 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
     HVAC modes:
       OFF       — power off (func 0x01, data 0x01)
       COOL      — cooling mode
-      HEAT      — heating mode
       FAN_ONLY  — fan mode and vent mode both map here (protocols 0x03 and 0x08)
-      DRY       — dehumidify mode
 
     Presets (active within the current HVAC mode):
       none           — standard operation
@@ -322,7 +318,7 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
     functional difference between them is unconfirmed without hardware testing.
     """
 
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.FAN_ONLY, HVACMode.DRY]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.FAN_ONLY]
     _attr_preset_modes = [AC_PRESET_NONE, AC_PRESET_ENERGY_SAVING, AC_PRESET_SLEEP, AC_PRESET_TURBO]
     _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -340,10 +336,8 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
     # Map from AC protocol mode codes to HA HVACMode.
     _MODE_TO_HVAC: dict[int, HVACMode] = {
         _AC_MODE_COOL: HVACMode.COOL,
-        _AC_MODE_HEAT: HVACMode.HEAT,
         _AC_MODE_FAN: HVACMode.FAN_ONLY,
         _AC_MODE_VENT: HVACMode.FAN_ONLY,   # unconfirmed; see class docstring
-        _AC_MODE_DEHUMIDIFY: HVACMode.DRY,
     }
 
     # Preset mode codes — these modify the current HVAC mode rather than replacing it.
@@ -439,9 +433,7 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
                 await self.coordinator._client.send_command(0x01, bytes([0x02]))
             mode_map = {
                 HVACMode.COOL: _AC_MODE_COOL,
-                HVACMode.HEAT: _AC_MODE_HEAT,
                 HVACMode.FAN_ONLY: _AC_MODE_FAN,
-                HVACMode.DRY: _AC_MODE_DEHUMIDIFY,
             }
             code = mode_map.get(hvac_mode)
             if code is not None:
@@ -456,9 +448,7 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
             # Restore the last base HVAC mode.
             mode_map = {
                 HVACMode.COOL: _AC_MODE_COOL,
-                HVACMode.HEAT: _AC_MODE_HEAT,
                 HVACMode.FAN_ONLY: _AC_MODE_FAN,
-                HVACMode.DRY: _AC_MODE_DEHUMIDIFY,
             }
             code = mode_map.get(self._last_hvac_mode, _AC_MODE_COOL)
             await self.coordinator._client.send_command(0x02, bytes([code]))

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -278,11 +278,6 @@ class TestACClimateState:
         entity, _ = _ac_entity(data=data)
         assert entity.hvac_mode == HVACMode.OFF
 
-    def test_hvac_mode_dry(self):
-        data = {**_make_ac_coord().data, "mode": 7}
-        entity, _ = _ac_entity(data=data)
-        assert entity.hvac_mode == HVACMode.DRY
-
     def test_preset_none_for_base_modes(self):
         entity, _ = _ac_entity()
         assert entity.preset_mode == AC_PRESET_NONE
@@ -305,11 +300,6 @@ class TestACClimateState:
     def test_fan_mode(self):
         entity, _ = _ac_entity()
         assert entity.fan_mode == "3"
-
-    def test_hvac_mode_heat(self):
-        data = {**_make_ac_coord().data, "mode": 2}
-        entity, _ = _ac_entity(data=data)
-        assert entity.hvac_mode == HVACMode.HEAT
 
     def test_hvac_mode_fan_only(self):
         data = {**_make_ac_coord().data, "mode": 3}
@@ -351,24 +341,24 @@ class TestACClimateOptimistic:
     def test_optimistic_hvac_mode_returned_immediately(self):
         entity, coord = _ac_entity()
         # Set optimistic before coordinator confirms.
-        entity._optimistic_hvac_mode = HVACMode.HEAT
+        entity._optimistic_hvac_mode = HVACMode.FAN_ONLY
         coord._post_command_fast_polls = 3
-        assert entity.hvac_mode == HVACMode.HEAT
+        assert entity.hvac_mode == HVACMode.FAN_ONLY
 
     def test_optimistic_hvac_mode_clears_when_confirmed(self):
-        # Coordinator data already shows HEAT — optimistic agrees, so it clears.
-        data = {**_make_ac_coord().data, "mode": 2}
+        # Coordinator data already shows FAN_ONLY — optimistic agrees, so it clears.
+        data = {**_make_ac_coord().data, "mode": 3}
         entity, coord = _ac_entity(data=data)
-        entity._optimistic_hvac_mode = HVACMode.HEAT
+        entity._optimistic_hvac_mode = HVACMode.FAN_ONLY
         coord._post_command_fast_polls = 3
         result = entity.hvac_mode
-        assert result == HVACMode.HEAT
+        assert result == HVACMode.FAN_ONLY
         assert entity._optimistic_hvac_mode is None
 
     def test_optimistic_hvac_mode_clears_when_fast_polls_exhausted(self):
         # Fast poll window expired without confirmation — revert to actual.
         entity, coord = _ac_entity()  # actual = COOL (mode=1)
-        entity._optimistic_hvac_mode = HVACMode.HEAT
+        entity._optimistic_hvac_mode = HVACMode.FAN_ONLY
         coord._post_command_fast_polls = 0
         result = entity.hvac_mode
         assert result == HVACMode.COOL
@@ -410,11 +400,6 @@ class TestACClimateActions:
         assert calls[0].args == (0x01, bytes([0x02]))
         assert calls[1].args == (0x02, bytes([0x01]))
 
-    async def test_set_hvac_dry(self):
-        entity, coord = _ac_entity()
-        await entity.async_set_hvac_mode(HVACMode.DRY)
-        coord._client.send_command.assert_called_once_with(0x02, bytes([0x07]))
-
     async def test_set_preset_energy_saving(self):
         entity, coord = _ac_entity()
         await entity.async_set_preset_mode(AC_PRESET_ENERGY_SAVING)
@@ -422,9 +407,9 @@ class TestACClimateActions:
 
     async def test_set_preset_none_restores_last_mode(self):
         entity, coord = _ac_entity()
-        entity._last_hvac_mode = HVACMode.HEAT
+        entity._last_hvac_mode = HVACMode.FAN_ONLY
         await entity.async_set_preset_mode(AC_PRESET_NONE)
-        coord._client.send_command.assert_called_once_with(0x02, bytes([0x02]))
+        coord._client.send_command.assert_called_once_with(0x02, bytes([0x03]))
 
     async def test_set_temperature_celsius(self):
         entity, coord = _ac_entity(temp_unit=UnitOfTemperature.CELSIUS)
@@ -470,11 +455,11 @@ class TestACClimateActions:
     async def test_turn_on_restores_last_hvac_mode(self):
         # Device is off; async_turn_on should power on and restore last mode.
         entity, coord = _ac_entity(data={**_make_ac_coord().data, "power": 0x01})
-        entity._last_hvac_mode = HVACMode.HEAT
+        entity._last_hvac_mode = HVACMode.FAN_ONLY
         await entity.async_turn_on()
         calls = coord._client.send_command.call_args_list
-        assert calls[0].args == (0x01, bytes([0x02]))   # power on
-        assert calls[1].args == (0x02, bytes([0x02]))   # HEAT = 0x02
+        assert calls[0].args == (0x01, bytes([0x02]))      # power on
+        assert calls[1].args == (0x02, bytes([0x03]))      # FAN_ONLY = 0x03
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -333,6 +333,48 @@ class TestACClimateState:
 
 
 # ---------------------------------------------------------------------------
+# AC — hvac_action
+# ---------------------------------------------------------------------------
+
+
+class TestACClimateAction:
+    def test_action_off_when_powered_off(self):
+        data = {**_make_ac_coord().data, "power": 0x01}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_action == HVACAction.OFF
+
+    def test_action_off_when_fault_active(self):
+        data = {**_make_ac_coord().data, "fault_code": 1}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_action == HVACAction.OFF
+
+    def test_action_cooling_in_cool_mode(self):
+        entity, _ = _ac_entity()  # default: on, mode=1 (cool)
+        assert entity.hvac_action == HVACAction.COOLING
+
+    def test_action_fan_in_fan_mode(self):
+        data = {**_make_ac_coord().data, "mode": 3}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_action == HVACAction.FAN
+
+    def test_action_fan_in_vent_mode(self):
+        data = {**_make_ac_coord().data, "mode": 8}
+        entity, _ = _ac_entity(data=data)
+        assert entity.hvac_action == HVACAction.FAN
+
+    def test_action_none_when_no_data(self):
+        entity, _ = _ac_entity(data=None)
+        assert entity.hvac_action is None
+
+    def test_action_uses_last_hvac_mode_during_preset(self):
+        # Preset active (energy saving, mode=4) — action resolves from last base mode.
+        data = {**_make_ac_coord().data, "mode": 4}
+        entity, _ = _ac_entity(data=data)
+        entity._last_hvac_mode = HVACMode.COOL
+        assert entity.hvac_action == HVACAction.COOLING
+
+
+# ---------------------------------------------------------------------------
 # AC — optimistic state
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #48

Two issues in the AC climate entity:

**Remove HEAT and DRY modes**

Both were added based on the V1.01 protocol spec. Hardware confirms neither is available on the 2000R. Removes the ability to send commands the device can't execute.

**Add hvac_action**

Without this property the climate tile showed no active state — no blue fade, no "Cooling" label. The AC protocol has no dedicated active/idle signal, so action is inferred from power state and mode: off → `OFF`, cool → `COOLING`, fan/vent → `FAN`. Presets resolve via `_last_hvac_mode`.