### PR TITLE
fix: rename AC preset labels to match device display

### DIFF
--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -54,10 +54,10 @@ _AC_MODE_TURBO = 6
 _AC_MODE_VENT = 8
 
 # Preset names used in HA for AC modes that don't map directly to HVACMode.
-AC_PRESET_NONE = "none"
-AC_PRESET_ENERGY_SAVING = "energy_saving"
-AC_PRESET_SLEEP = "sleep"
-AC_PRESET_TURBO = "turbo"
+AC_PRESET_NONE = "Cooling"
+AC_PRESET_ENERGY_SAVING = "Eco"
+AC_PRESET_SLEEP = "Sleep"
+AC_PRESET_TURBO = "Turbo"
 
 # Fan modes exposed to HA — string labels matching gear/speed numbers.
 FAN_MODES = ["1", "2", "3", "4", "5"]
@@ -396,6 +396,8 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
     @property
     def preset_mode(self) -> str | None:
         if self.coordinator.data is None:
+            return None
+        if self.hvac_mode != HVACMode.COOL:
             return None
         mode_code = self.coordinator.data["mode"]
         actual = self._PRESET_CODES.get(mode_code, AC_PRESET_NONE)

--- a/custom_components/velit/climate.py
+++ b/custom_components/velit/climate.py
@@ -98,6 +98,7 @@ class VelitHeaterClimateEntity(CoordinatorEntity[VelitHeaterCoordinator], Climat
     _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
+    _attr_translation_key = "heater"
 
     @property
     def supported_features(self) -> ClimateEntityFeature:
@@ -323,6 +324,7 @@ class VelitACClimateEntity(CoordinatorEntity[VelitACCoordinator], ClimateEntity)
     _attr_fan_modes = FAN_MODES
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1.0
+    _attr_translation_key = "ac"
     _attr_min_temp = float(AC_MIN_TEMP_C)
     _attr_max_temp = float(AC_MAX_TEMP_C)
     _attr_supported_features = (

--- a/custom_components/velit/strings.json
+++ b/custom_components/velit/strings.json
@@ -63,6 +63,22 @@
     }
   },
   "entity": {
+    "climate": {
+      "heater": {
+        "state_attributes": {
+          "fan_mode": {
+            "name": "Fan Level"
+          }
+        }
+      },
+      "ac": {
+        "state_attributes": {
+          "fan_mode": {
+            "name": "Fan Level"
+          }
+        }
+      }
+    },
     "button": {
       "cleaning": {
         "name": "Cleaning"

--- a/custom_components/velit/translations/en.json
+++ b/custom_components/velit/translations/en.json
@@ -63,6 +63,22 @@
     }
   },
   "entity": {
+    "climate": {
+      "heater": {
+        "state_attributes": {
+          "fan_mode": {
+            "name": "Fan Level"
+          }
+        }
+      },
+      "ac": {
+        "state_attributes": {
+          "fan_mode": {
+            "name": "Fan Level"
+          }
+        }
+      }
+    },
     "button": {
       "cleaning": {
         "name": "Cleaning"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -306,6 +306,11 @@ class TestACClimateState:
         entity, _ = _ac_entity(data=data)
         assert entity.hvac_mode == HVACMode.FAN_ONLY
 
+    def test_preset_none_in_fan_only_mode(self):
+        data = {**_make_ac_coord().data, "mode": 3}
+        entity, _ = _ac_entity(data=data)
+        assert entity.preset_mode is None
+
     def test_hvac_mode_none_when_no_data(self):
         entity, _ = _ac_entity(data=None)
         assert entity.hvac_mode is None


### PR DESCRIPTION
Closes #50

AC preset modes were displaying internal protocol strings verbatim in
the HA UI ("none", "energy_saving", "sleep", "turbo"). This renames
them to match the labels shown on the physical device display.

**Changes**
- `none` → `Cooling`
- `energy_saving` → `Eco`
- `sleep` → `Sleep`
- `turbo` → `Turbo`

Also guards `preset_mode` to return `None` when the AC is in FAN_ONLY
mode, preventing "Cooling" from appearing as the preset label in a
context where it does not apply.

Renames the fan mode control label from "Fan mode" to "Fan Level" on
both heater and AC climate entities.

**Testing**
- 239 tests passing
- AC owner hardware validation pending — branch open for testing before merge